### PR TITLE
fixed typo dcom_register_rountine to dcom_register_routine

### DIFF
--- a/epan/dissectors/packet-dcom-sysact.c
+++ b/epan/dissectors/packet-dcom-sysact.c
@@ -1111,17 +1111,17 @@ dissect_dcom_ScmReplyInfo(tvbuff_t *tvb, gint offset, packet_info *pinfo,
 static void
 sysact_register_routines(void)
 {
-    dcom_register_rountine(dissect_dcom_ActivationProperties, &iid_ActivationPropertiesIn);
-    dcom_register_rountine(dissect_dcom_ActivationProperties, &iid_ActivationPropertiesOut);
-    dcom_register_rountine(dissect_dcom_SpecialSystemProperties, &clsid_SpecialSystemProperties);
-    dcom_register_rountine(dissect_dcom_InstantiationInfo, &clsid_InstantiationInfo);
-    dcom_register_rountine(dissect_dcom_ActivationContextInfo, &clsid_ActivationContextInfo);
-    dcom_register_rountine(dissect_dcom_ContextMarshaler, &clsid_ContextMarshaler);
-    dcom_register_rountine(dissect_dcom_SecurtiyInfo, &clsid_SecurityInfo);
-    dcom_register_rountine(dissect_dcom_LocationInfo, &clsid_ServerLocationInfo);
-    dcom_register_rountine(dissect_dcom_ScmRqstInfo, &clsid_ScmRequestInfo);
-    dcom_register_rountine(dissect_dcom_PropsOutInfo, &clsid_PropsOutInfo);
-    dcom_register_rountine(dissect_dcom_ScmReplyInfo, &clsid_ScmReplyInfo);
+    dcom_register_routine(dissect_dcom_ActivationProperties, &iid_ActivationPropertiesIn);
+    dcom_register_routine(dissect_dcom_ActivationProperties, &iid_ActivationPropertiesOut);
+    dcom_register_routine(dissect_dcom_SpecialSystemProperties, &clsid_SpecialSystemProperties);
+    dcom_register_routine(dissect_dcom_InstantiationInfo, &clsid_InstantiationInfo);
+    dcom_register_routine(dissect_dcom_ActivationContextInfo, &clsid_ActivationContextInfo);
+    dcom_register_routine(dissect_dcom_ContextMarshaler, &clsid_ContextMarshaler);
+    dcom_register_routine(dissect_dcom_SecurtiyInfo, &clsid_SecurityInfo);
+    dcom_register_routine(dissect_dcom_LocationInfo, &clsid_ServerLocationInfo);
+    dcom_register_routine(dissect_dcom_ScmRqstInfo, &clsid_ScmRequestInfo);
+    dcom_register_routine(dissect_dcom_PropsOutInfo, &clsid_PropsOutInfo);
+    dcom_register_routine(dissect_dcom_ScmReplyInfo, &clsid_ScmReplyInfo);
 
     return;
 }

--- a/epan/dissectors/packet-dcom.c
+++ b/epan/dissectors/packet-dcom.c
@@ -1945,7 +1945,7 @@ dissect_dcom_STDOBJREF(tvbuff_t *tvb, gint offset, packet_info *pinfo,
  */
 
 int
-dcom_register_rountine(dcom_dissect_fn_t routine, e_guid_t* uuid)
+dcom_register_routine(dcom_dissect_fn_t routine, e_guid_t* uuid)
 {
 	dcom_marshaler_t *marshaler;
 

--- a/epan/dissectors/packet-dcom.h
+++ b/epan/dissectors/packet-dcom.h
@@ -83,7 +83,7 @@ WS_DLL_PUBLIC dcom_interface_t *dcom_interface_find(packet_info *pinfo, const ad
 #ifdef DEBUG
 extern void dcom_interface_dump(void);
 #endif
-extern int dcom_register_rountine(dcom_dissect_fn_t routine, e_guid_t* uuid);
+extern int dcom_register_routine(dcom_dissect_fn_t routine, e_guid_t* uuid);
 extern void dcom_register_common_routines_(void);
 
 extern dcom_dissect_fn_t dcom_get_rountine_by_uuid(const e_guid_t* uuid);


### PR DESCRIPTION
function com_register_rountine is extern, I can make a stub so this typo
could be phased out