### PR TITLE
LTE message parsing

### DIFF
--- a/epan/dissectors/packet-gsmtap.h
+++ b/epan/dissectors/packet-gsmtap.h
@@ -46,6 +46,8 @@
 #define GSMTAP_TYPE_GMR1_UM		0x0a	/* GMR-1 L2 packets */
 #define GSMTAP_TYPE_UMTS_RLC_MAC	0x0b
 #define GSMTAP_TYPE_UMTS_RRC		0x0c
+#define GSMTAP_TYPE_LTE_RRC		0x0d	/* LTE interface */
+#define GSMTAP_TYPE_LTE_MAC		0x0e	/* LTE interface */
 #define GSMTAP_TYPE_OSMOCORE_LOG	0x10	/* libosmocore logging */
 
 /* ====== DO NOT MAKE UNAPPROVED MODIFICATIONS HERE ===== */


### PR DESCRIPTION
Adds LTE message support. This code is borrowed from a patch proposed by altaf329@gmail.com in june 2015 and adapted to fit current wireshark code.