### PR TITLE
Fixing typo in the minimum TTL field

### DIFF
--- a/epan/dissectors/packet-dns.c
+++ b/epan/dissectors/packet-dns.c
@@ -4661,7 +4661,7 @@ proto_register_dns(void)
         NULL, HFILL }},
 
     { &hf_dns_soa_minimum_ttl,
-      { "Minimum TTL", "dns.soa.mininum_ttl",
+      { "Minimum TTL", "dns.soa.minimum_ttl",
         FT_UINT32, BASE_DEC, NULL, 0x0,
         NULL, HFILL }},
 


### PR DESCRIPTION
The field minimum_ttl was missped as mininum_ttl.
I would suggest also updating the documentation at: https://www.wireshark.org/docs/dfref/d/dns.html#