### PR TITLE
epan: print leading zeroes for sub-second values.

### DIFF
--- a/epan/print.c
+++ b/epan/print.c
@@ -1332,7 +1332,7 @@ ek_write_field_value(field_info *fi, write_json_data* pdata)
 #endif
             if (tm != NULL) {
                 strftime(time_string, sizeof(time_string), "%FT%T", tm);
-                json_dumper_value_anyf(pdata->dumper, "\"%s.%uZ\"", time_string, t->nsecs);
+                json_dumper_value_anyf(pdata->dumper, "\"%s.%09uZ\"", time_string, t->nsecs);
             } else {
                 json_dumper_value_anyf(pdata->dumper, "\"Not representable\"");
             }


### PR DESCRIPTION
We could see this issue when comparing frame_frame_time and frame_frame_time_epoch
"frame_frame_time" : "2021-04-08T10:13:55.46302619Z"
"frame_frame_time_epoch" : "1617876835.046302619",