### PR TITLE
Fixed incorrect calculating hash from quic_cid_t

### DIFF
--- a/epan/dissectors/packet-quic.c
+++ b/epan/dissectors/packet-quic.c
@@ -869,7 +869,7 @@ quic_connection_hash(gconstpointer key)
 {
     const quic_cid_t *cid = (const quic_cid_t *)key;
 
-    return wmem_strong_hash((const guint8 *)cid, cid->len);
+    return wmem_strong_hash((const guint8 *)cid, sizeof(quic_cid_t) - sizeof(cid->cid) + cid->len);
 }
 
 static gboolean


### PR DESCRIPTION
I seems to have been a long time since QUIC has been released and its quic_connection_hash has been written
Actually, my assumption is it has been incorrect and calculated hash from quic_cid_t lacking the last byte of the CID byte array
So far hash is calculated considering `len` as a byte field and `len - 1` bytes of CID byte array rather than `len` byte field + `len` bytes of CID byte array given in total len + 1 bytes to consider what seems to be reasonable. At now it takes into consideration `len` bytes
Correct me if I am wrong
Thank you