### PR TITLE
Fix inline documentation for RTPS NACK_FRAG submessage byte layout

### DIFF
--- a/epan/dissectors/packet-rtps.c
+++ b/epan/dissectors/packet-rtps.c
@@ -9654,7 +9654,7 @@ static void dissect_NACK_FRAG(tvbuff_t *tvb, packet_info *pinfo, gint offset, gu
    * | EntityId writerEntityId                                       |
    * +---------------+---------------+---------------+---------------+
    * |                                                               |
-   * + SequenceNumberSet writerSN                                    +
+   * + SequenceNumber writerSN                                       +
    * |                                                               |
    * +---------------+---------------+---------------+---------------+
    * |                                                               |


### PR DESCRIPTION
In the RTPS dissector, a code comment describes the `writerSN` field in the NACK_FRAG submessage as a `SequenceNumberSet`. It looks like this field is actually a `SequenceNumber`, though.