### PR TITLE
Added TCP heuristic and expanded optommp addresses and descriptions.

### DIFF
--- a/epan/dissectors/packet-optommp.c
+++ b/epan/dissectors/packet-optommp.c
@@ -13,6 +13,7 @@
 
 #include <epan/packet.h>
 #include "packet-tcp.h"
+#include "packet-udp.h"
 
 #define OPTO_FRAME_HEADER_LEN 8
 #define OPTOMMP_MIN_LENGTH 12
@@ -79,31 +80,37 @@ static const value_string optommp_rcode_meanings[] = {
 };
 
 static const range_string optommp_mm_areas[] = {
-    { 0xf0100000,   0xf01bffff,
-            "Expanded Analog & Digital Point Configuration - Read/Write" },
+    {   0xf0100000, 0xf01bffff,
+            "Expanded Analog & Digital Channel Configuration - Read/Write" },
     {   0xf01c0000, 0xf01c7fff,
-            "Expanded Analog Point Calc & Set - Read/Write" },
+            "Expanded Analog Channel Calc & Set - Read/Write" },
     {   0xf01d4000, 0xf01dffff,
-            "Expanded Analog Point Read & Clear - Read/Write" },
+            "Expanded Analog Channel Read & Clear - Read/Write" },
+    {   0xF01E0000, 0xF021FFFF,
+            "Expanded Digital Channel Read - Read Only" },
+    {   0xF0220000, 0xF025FFFF,
+            "Expanded Digital Channel Write - Read/Write" },
     {   0xf0260000, 0xf029ffff,
-            "Expanded Analog Point Read - Read" },
+            "Expanded Analog Channel Read - Read Only" },
     {   0xf02a0000, 0xf02dffff,
-            "Expanded Analog Point Write - Read/Write" },
+            "Expanded Analog Channel Write - Read/Write" },
     {   0xf02e0000, 0xf02f7fff,
-            "Expanded Digital Point Read & Clear - Read/Write" },
+            "Expanded Digital Channel Read & Clear - Read/Write" },
+    {   0xF02F8000, 0xF02FFFFF,
+            "I/O Channel Data Preserved Area (64-bit energy counters)" },
     {   0xf0300000, 0xf030024b,
             "Status Area Read - Read Only" },
+    {   0xF0380000, 0xF03802B3,
+            "Status Write Area - Read/Write" },
     {   0xf0310400, 0xf031110f,
             "Communications Port Configuration - Read/Write" },
     {   0xf0329000, 0xf032efff,
             "Serial Pass-Through - Read/Write" },
     {   0xf0350000, 0xf0350023,
             "Date and Time Configuration - Read/Write" },
-    {   0xf0380000, 0xf0380297,
-            "Status Area Write - Read/Write" },
     {   0xf0390000, 0xf0390003,
             "Modbus Configuration - Read/Write" },
-    {   0xf03a0004, 0xf03a0073,
+    {   0xf03a0004, 0xf03a007F,
             "Network Security Configuration - Read/Write" },
     {   0xf03a1000, 0xf03a1fff,
             "SSI Module Configuration - Read/Write" },
@@ -123,7 +130,7 @@ static const range_string optommp_mm_areas[] = {
             "PPP Configuration - Read/Write" },
     {   0xf03eb800, 0xf03fb827,
             "PPP Status - Read Only" },
-    {   0xf03fffc4, 0xf03fffff,
+    {   0xf03fffc0, 0xf03fffff,
             "Streaming Configuration - Read/Write" },
     {   0xf0400000, 0xf04001ff,
             "Digital Bank Read - Read Only" },
@@ -134,15 +141,15 @@ static const range_string optommp_mm_areas[] = {
     {   0xf0700000, 0xf07001ff,
             "Analog Bank Write - Read/Write" },
     {   0xf0800000, 0xf0800fd3,
-            "Digital Point Read - Read Only" },
+            "Digital Channel Read - Read Only" },
     {   0xf0900000, 0xf0900fcf,
-            "Digital Point Write - Read/Write" },
+            "Digital Channel Write - Read/Write" },
     {   0xf0a00000, 0xf0a00fcf,
-            "Old Analog Point Read - Read Only" },
+            "Old Analog Channel Read - Read Only" },
     {   0xf0b00000, 0xf0b00fcf,
-            "Old Analog Point Write - Read/Write" },
+            "Old Analog Channel Write - Read/Write" },
     {   0xf0c00000, 0xf0c011ff,
-            "Old A&D Point Configuration Information - Read/Write" },
+            "Old A&D Channel Configuration Information - Read/Write" },
     {   0xf0d00000, 0xf0d01fff,
             "Old Digital Events and Reactions - Read/Write" },
     {   0xf0d40000, 0xf0d4ffff,
@@ -150,17 +157,27 @@ static const range_string optommp_mm_areas[] = {
     {   0xf0d80000, 0xf0dc81ff,
             "Scratch Pad - Read/Write" },
     {   0xf0e00000, 0xf0e001ff,
-            "Old Analog Point Calculation and Set - Read Only" },
+            "Old Analog Channel Calculation and Set - Read Only" },
     {   0xf0f00000, 0xf0f002ff,
             "Old Digital Read and Clear - Read Only" },
     {   0xf0f80000, 0xf0f801ff,
             "Old Analog Read and Clear/Restart - Read Only" },
     {   0xf1000000, 0xf100021f,
             "Streaming - Read Only" },
+    {   0xF1000300, 0xF1000BFF,
+            "Expanded Streaming Data - Read Only" },
     {   0xf1001000, 0xf10017ff,
             "Analog EU or Digital Counter Packed Data - Read" },
     {   0xf1001800, 0xf100183f,
             "Digital Packed Data - Read/Write" },
+    {   0xf1001900, 0xF10019FF,
+            "Expanded Digital Packed Data Read - Read Only" },
+    {   0xF1001A00, 0xF1001A7F,
+            "Expanded Digital Packed Must On/Off (MOMO) - Read/Write" },
+    {   0xF1002000, 0xF100607F,
+            "Analog/Digital Channel Quality of Data - Read Only" },
+    {   0xF1008000, 0xF100BFFF,
+            "Expanded Analog EU or Digital Counter (Feature) Packed Area - Read Only" },
     {   0xf1100000, 0xf1101fff,
             "Alarm Event Settings - Read/Write" },
     {   0xf1200000, 0xf12111ff,
@@ -173,14 +190,30 @@ static const range_string optommp_mm_areas[] = {
             "Wiegand Serial Event Configuration - Read/Write" },
     {   0xf1808000, 0xf1809ffe,
             "SNAP High-Density Digital - Read Only" },
+    {   0xF1809000, 0xF1809FFF,
+            "SNAP High-Density Digital Read Counter Area - Read Only" },
     {   0xf180a000, 0xf180bffe,
-            "SNAP High-Density Digital Read and Clear - Read/Write" },
+            "SNAP High-Density Digital Read and Clear Latches - Read/Write" },
+    {   0xF180B000, 0xF180BFFF,
+            "SNAP High-Density Digital Read and Clear Counter - Read/Write" },
     {   0xf180c000, 0xf180c3fe,
             "SNAP High-Density Digital Write - Read/Write" },
     {   0xf2000000, 0xf2002edf,
             "PID Configuration and Status - Read/Write" },
     {   0xf2100000, 0xf21047ff,
             "PID Configuration and Status - Read/Write" },
+    {   0xF2180000, 0xF218137F,
+            "PID Names" },
+    {   0xF2280000, 0xF228FFFF,
+            "Public I/O Tag Configuration (Channels 0-31) - Read/Write" },
+    {   0xF2290000, 0xF2295FFF,
+            "Public Tag Revision Number" },
+    {   0xF2293000, 0xF228FFFF,
+            "Public PID Tag Configuration" },
+    {   0xF22A0000, 0xF22AFFFF,
+            "Public I/O Tag Configuration (Channels 32-63)  - Read/Write" },
+    {   0xF22B0000, 0xF22B01FF,
+            "Public Scratchpad Tag Configuration" },
     {   0xf3000000, 0xf3000707,
             "Data Logging Configuration - Read/Write" },
     {   0xf3020000, 0xf302176f,
@@ -199,10 +232,13 @@ static const range_string optommp_mm_areas[] = {
             "WLAN Configuration - Read/Write" },
     {   0xf8000000, 0xf800000b,
             "WLAN Enable - Read/Write" },
+    {   0xF8110000, 0xF81107FF,
+            "Module Build Info" },
     {   0xfffff008, 0xfffff077,
             "IP Settings - Read/Write" },
     {   0,          0,          NULL }
 };
+
 
 /* Function Prototypes */
 static guint get_optommp_message_len(packet_info *pinfo _U_, tvbuff_t *tvb,
@@ -246,10 +282,53 @@ static void dissect_optommp_data_block_byte(proto_item **ti, proto_tree *tree,
 static void dissect_optommp_data_block_quadlet(proto_item **ti, proto_tree
     *tree, tvbuff_t *tvb, guint *poffset);
 static gint optommp_has_destination_offset(guint8 tcode);
+static gboolean test_optommp(packet_info* pinfo _U_, tvbuff_t* tvb,
+    int offset _U_, void* data _U_);
+static guint dissect_optommp_tcp(tvbuff_t* tvb, packet_info* pinfo, proto_tree
+    *tree, void* data);
+static gboolean dissect_optommp_heur_tcp(tvbuff_t* tvb, packet_info* pinfo, proto_tree
+    *tree, void* data);
+static guint dissect_optommp_udp(tvbuff_t* tvb, packet_info* pinfo, proto_tree
+    *tree, void* data);
+static gboolean dissect_optommp_heur_udp(tvbuff_t* tvb, packet_info* pinfo, proto_tree
+    *tree, void* data);
 
 void proto_register_optommp(void);
 void proto_reg_handoff_optommp(void);
 
+/****************************************************************************
+function:       test_optommp()
+parameters:     pinfo: not used
+                tvb: poiner to packet data
+                offset: not used
+                data: not used
+purpose:        Tests whether or not a packet signature might be 
+				dissectable by OptoMMP.
+****************************************************************************/
+static gboolean test_optommp(packet_info* pinfo _U_, tvbuff_t* tvb, int offset _U_, void* data _U_)
+{
+    /* 0) Verify needed bytes available in tvb so tvb_get...() doesn't cause exception. */
+    if (tvb_captured_length(tvb) < 4) // We only examine the first four bytes of the packet.
+        return FALSE;
+
+    /* 1) first two bytes must be 0x0, because destination_id unused. */
+    if (tvb_get_guint16(tvb, 0, ENC_BIG_ENDIAN) != 0x0)
+        return FALSE;
+
+    /* 2) first two LSB's of third byte must be zero, because rt unused */
+    if ((tvb_get_guint8(tvb, 2) & 0x3) != 0x0)
+        return FALSE;
+
+    /* 3) four MSB's of fourth byte are in range (0x0 - 0x7)
+        first four LSB's of fourth byte must be zero AND */
+    guint8 tcode = tvb_get_guint8(tvb, 3) & 0xF0;
+    guint8 pri = tvb_get_guint8(tvb, 3) & 0xF;
+    if (tcode > 0x70 || tcode == 0x3 || pri != 0)
+        return FALSE;
+
+    /* Assume it's an OptoMMP packet ... */
+    return TRUE;
+}
 
 /****************************************************************************
 function:       get_optommp_message_len()
@@ -880,6 +959,85 @@ void proto_register_optommp(void)
 }
 
 /****************************************************************************
+function:       dissect_optommp_tcp()
+parameters:     pinfo: not used
+                tvb: poiner to packet data
+                offset: not used
+                data: not used
+purpose:        The method called by the heuristic dissector for dissecting TCP packets.
+****************************************************************************/
+static guint dissect_optommp_tcp(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data)
+{
+    tcp_dissect_pdus(tvb, pinfo, tree, TRUE, OPTOMMP_MIN_LENGTH,
+        get_optommp_message_len, dissect_optommp, data);
+    return tvb_reported_length(tvb);
+}
+
+/****************************************************************************
+function:       dissect_optommp_heur_tcp()
+parameters:     pinfo: not used
+                tvb: poiner to packet data
+                offset: not used
+                data: not used
+purpose:        Tests the packet format, if a match, sets conversation
+				to use this dissector.
+****************************************************************************/
+static gboolean dissect_optommp_heur_tcp(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data)
+{
+    if (!test_optommp(pinfo, tvb, 0, data))
+        return FALSE;
+
+	/*   sets the converation between two IPs communicating on
+		 a port to use OptoMMP dissection. */
+    conversation_t* conversation = find_or_create_conversation(pinfo);
+    conversation_set_dissector(conversation, optommp_tcp_handle);
+
+    /*   and do the dissection */
+    dissect_optommp_tcp(tvb, pinfo, tree, data);
+
+    return (TRUE);
+}
+
+/****************************************************************************
+function:       dissect_optommp_udp()
+parameters:     pinfo: not used
+                tvb: poiner to packet data
+                offset: not used
+                data: not used
+purpose:        The method called by the heuristic dissector for dissecting UDP packets.
+****************************************************************************/
+static guint dissect_optommp_udp(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data)
+{
+    udp_dissect_pdus(tvb, pinfo, tree, OPTOMMP_MIN_LENGTH, NULL,
+        get_optommp_message_len, dissect_optommp, data);
+    return tvb_reported_length(tvb);
+}
+
+/****************************************************************************
+function:       dissect_optommp_heur_udp()
+parameters:     pinfo: not used
+                tvb: poiner to packet data
+                offset: not used
+                data: not used
+purpose:        The method called by the heuristic dissector for dissecting TCP packets.
+****************************************************************************/
+static gboolean dissect_optommp_heur_udp(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree, void* data)
+{
+    if (!test_optommp(pinfo, tvb, 0, data))
+        return FALSE;
+
+	/*   sets the converation between two IPs communicating on
+		 a port to use OptoMMP dissection. */
+    conversation_t* conversation = find_or_create_conversation(pinfo);
+    conversation_set_dissector(conversation, optommp_udp_handle);
+
+    /*   and do the dissection */
+    dissect_optommp_udp(tvb, pinfo, tree, data);
+
+    return (TRUE);
+}
+
+/****************************************************************************
 function:       proto_reg_handoff()
 parameters:     void
 purpose:        plug into wireshark with a handle
@@ -888,6 +1046,19 @@ void proto_reg_handoff_optommp(void)
 {
     optommp_tcp_handle = create_dissector_handle(dissect_optommp_reassemble_tcp, proto_optommp);
     optommp_udp_handle = create_dissector_handle(dissect_optommp_reassemble_udp, proto_optommp);
+
+    static int optommp_inited = FALSE;
+
+    if (!optommp_inited)
+    {
+        /* register as heuristic dissector for both TCP and UDP */
+        heur_dissector_add("tcp", dissect_optommp_heur_tcp, "OptoMMP over TCP",
+            "optommp_tcp", proto_optommp, HEURISTIC_ENABLE);
+        heur_dissector_add("udp", dissect_optommp_heur_udp, "OptoMMP over UDP",
+            "optommp_udp", proto_optommp, HEURISTIC_ENABLE);
+
+        optommp_inited = TRUE;
+    }
 
     dissector_add_for_decode_as_with_preference("tcp.port", optommp_tcp_handle);
     dissector_add_for_decode_as_with_preference("udp.port", optommp_udp_handle);


### PR DESCRIPTION
Hello there, I'm an employee of Opto 22 and I've been tasked with adding an expanded range of memory addresses and corresponding descriptions to our protocol's dissector. I've also added heuristic methods for registering the dissector. Thank you for reviewing my pull request. 