### PR TITLE
new(dissectors,pcapng): added support for sysdig new block type with 4B payload len

### DIFF
--- a/epan/dissectors/file-pcapng.c
+++ b/epan/dissectors/file-pcapng.c
@@ -260,6 +260,10 @@ static const value_string block_type_vals[] = {
     { 0x0000000A,  "Decryption Secrets Block" },
     { 0x00000204,  "Sysdig Event Block" },
     { 0x00000208,  "Sysdig Event Block with flags" },
+    { 0x00000216,  "Sysdig Event Block v2" },
+    { 0x00000217,  "Sysdig Event Block with flags v2" },
+    { 0x00000221,  "Sysdig Event Block v2 large payload" },
+    { 0x00000222,  "Sysdig Event Block with flags v2 large payload" },
     { 0x0A0D0D0A,  "Section Header Block" },
     { 0x80000001,  "Darwin Process Event Block" },
     { 0, NULL }

--- a/wiretap/pcapng_module.h
+++ b/wiretap/pcapng_module.h
@@ -30,6 +30,8 @@
 #define BLOCK_TYPE_SYSDIG_EVF             0x00000208 /* Sysdig Event Block with flags */
 #define BLOCK_TYPE_SYSDIG_EVENT_V2        0x00000216 /* Sysdig Event Block version 2 */
 #define BLOCK_TYPE_SYSDIG_EVF_V2          0x00000217 /* Sysdig Event Block with flags version 2 */
+#define BLOCK_TYPE_SYSDIG_EVENT_V2_LARGE  0x00000221 /* Sysdig Event Block version 2 with large payload */
+#define BLOCK_TYPE_SYSDIG_EVF_V2_LARGE    0x00000222 /* Sysdig Event Block with flags version 2 with large payload */
 #define BLOCK_TYPE_CB_COPY                0x00000BAD /* Custom Block which can be copied */
 #define BLOCK_TYPE_CB_NO_COPY             0x40000BAD /* Custom Block which should not be copied */
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

Hi!
Recently a PR to implement an Event Block Type v2 with large payload support was merged into https://github.com/falcosecurity/libs.  
The work is backward compatible as only new event types will make use of the new large block type.  
In this PR i implement support for this new block type into wireshark. 

Here is a screenshot with wireshark reading a larger than 64Kb event:
![Screenshot_20211021_155031](https://user-images.githubusercontent.com/5837210/139255110-3a0bee93-8888-46ff-a98c-6c01d00817b8.png) 
