### PR TITLE
pgsql backend message parse failure: error, notice

### DIFF
--- a/epan/dissectors/packet-pgsql.c
+++ b/epan/dissectors/packet-pgsql.c
@@ -543,6 +543,7 @@ static void dissect_pgsql_be_msg(guchar type, guint length, tvbuff_t *tvb,
             c = tvb_get_guint8(tvb, n);
             if (c == '\0')
                 break;
+            --length;
             s = tvb_get_stringz_enc(pinfo->pool, tvb, n+1, &siz, ENC_ASCII);
             i = hf_text;
             switch (c) {


### PR DESCRIPTION
for example: when we have message `"E" "\x0\x0\x0\x4e" "SFATAL\0" "VFATAL\0" "C28000\0" "Mencryption mode must be used\0" "RClientAuthentication\0" "\0x"` the rest of the length var will be equal to 6 = the number of parameters