### PR TITLE
Fix Windows compile Release and RelWithDebInfo

### DIFF
--- a/epan/dfilter/dfunctions.c
+++ b/epan/dfilter/dfunctions.c
@@ -26,7 +26,7 @@
 
 /* Convert an FT_STRING using a callback function */
 static gboolean
-string_walk(GSList *args, guint32 arg_count, GSList **retval, gchar(*conv_func)(gchar))
+string_walk(GSList *args, guint32 arg_count _U_, GSList **retval, gchar(*conv_func)(gchar))
 {
     GSList      *arg1;
     fvalue_t    *arg_fvalue;
@@ -75,7 +75,7 @@ df_func_upper(GSList *args, guint32 arg_count, GSList **retval)
 
 /* dfilter function: count() */
 static gboolean
-df_func_count(GSList *args, guint32 arg_count, GSList **retval)
+df_func_count(GSList *args, guint32 arg_count _U_, GSList **retval)
 {
     GSList   *arg1;
     fvalue_t *ft_ret;
@@ -96,7 +96,7 @@ df_func_count(GSList *args, guint32 arg_count, GSList **retval)
 
 /* dfilter function: string() */
 static gboolean
-df_func_string(GSList *args, guint32 arg_count, GSList **retval)
+df_func_string(GSList *args, guint32 arg_count _U_, GSList **retval)
 {
     GSList   *arg1;
     fvalue_t *arg_fvalue;
@@ -203,7 +203,7 @@ df_func_min(GSList *args, guint32 arg_count, GSList **retval)
 }
 
 static gboolean
-df_func_abs(GSList *args, guint32 arg_count, GSList **retval)
+df_func_abs(GSList *args, guint32 arg_count _U_, GSList **retval)
 {
     GSList   *arg1;
     fvalue_t *fv_arg, *new_fv;

--- a/epan/dfilter/semcheck.c
+++ b/epan/dfilter/semcheck.c
@@ -594,7 +594,7 @@ dfilter_fvalue_from_charconst(dfwork_t *dfw, ftenum_t ftype, stnode_t *st)
 /* If the LHS of a relation test is a FIELD, run some checks
  * and possibly some modifications of syntax tree nodes. */
 static void
-check_relation_LHS_FIELD(dfwork_t *dfw, stnode_op_t st_op,
+check_relation_LHS_FIELD(dfwork_t *dfw, stnode_op_t st_op _U_,
 		FtypeCanFunc can_func, gboolean allow_partial_value,
 		stnode_t *st_node,
 		stnode_t *st_arg1, stnode_t *st_arg2)
@@ -703,7 +703,7 @@ check_relation_LHS_FIELD(dfwork_t *dfw, stnode_op_t st_op,
 }
 
 static void
-check_relation_LHS_SLICE(dfwork_t *dfw, stnode_op_t st_op,
+check_relation_LHS_SLICE(dfwork_t *dfw, stnode_op_t st_op _U_,
 		FtypeCanFunc can_func _U_,
 		gboolean allow_partial_value,
 		stnode_t *st_node _U_,
@@ -786,7 +786,7 @@ check_relation_LHS_SLICE(dfwork_t *dfw, stnode_op_t st_op,
 /* If the LHS of a relation test is a FUNCTION, run some checks
  * and possibly some modifications of syntax tree nodes. */
 static void
-check_relation_LHS_FUNCTION(dfwork_t *dfw, stnode_op_t st_op,
+check_relation_LHS_FUNCTION(dfwork_t *dfw, stnode_op_t st_op _U_,
 		FtypeCanFunc can_func, gboolean allow_partial_value,
 		stnode_t *st_node,
 		stnode_t *st_arg1, stnode_t *st_arg2)

--- a/epan/dfilter/sttype-op.c
+++ b/epan/dfilter/sttype-op.c
@@ -21,7 +21,7 @@ typedef struct {
 #define OPER_MAGIC	0xab9009ba
 
 static gpointer
-oper_new(gpointer junk)
+oper_new(gpointer junk _U_)
 {
 	oper_t *oper;
 

--- a/epan/wslua/wslua_proto.c
+++ b/epan/wslua/wslua_proto.c
@@ -233,7 +233,7 @@ WSLUA_METHOD Proto_register_heuristic(lua_State* L) {
     Proto proto = checkProto(L,1);
     const gchar *listname = luaL_checkstring(L, WSLUA_ARG_Proto_register_heuristic_LISTNAME);
     const gchar *proto_name = proto->name;
-    const int top = lua_gettop(L);
+    const int top _U_ = lua_gettop(L);
     gchar *short_name;
 
     if (!proto_name || proto->hfid == -1) {

--- a/include/ws_attributes.h
+++ b/include/ws_attributes.h
@@ -28,7 +28,7 @@ extern "C" {
   /* This includes clang */
   #define _U_ __attribute__((unused))
 #elif defined(_MSC_VER)
-  #define _U_ __pragma(warning(suppress:4100))
+  #define _U_ __pragma(warning(suppress:4100 4189))
 #else
   #define _U_
 #endif

--- a/ui/qt/widgets/detachable_tabwidget.cpp
+++ b/ui/qt/widgets/detachable_tabwidget.cpp
@@ -155,7 +155,7 @@ void DragDropTabBar::mouseMoveEvent(QMouseEvent *event)
         _dragInitiated = true;
 
     if ((event->buttons() & Qt::LeftButton) && _dragInitiated) {
-        QMouseEvent * finishMouseMove = new QMouseEvent(QEvent::MouseMove, event->pos(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+        QMouseEvent * finishMouseMove = new QMouseEvent(QEvent::MouseMove, event->pos(), QCursor::pos(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
         QTabBar::mouseMoveEvent(finishMouseMove);
 
         QDrag * drag = new QDrag(this);


### PR DESCRIPTION
add _U_ to unused variables because of compile flag /W3; local variables have warning 4189; QMouseEvent constructur was deprecated in Qt 6.4