### PR TITLE
BGP: fix BGP-LS IPv6 Neighbor Address TLV s length

### DIFF
--- a/epan/dissectors/packet-bgp.c
+++ b/epan/dissectors/packet-bgp.c
@@ -4891,10 +4891,10 @@ static int decode_bgp_link_nlri_link_descriptors(tvbuff_t *tvb,
             break;
 
             case BGP_NLRI_TLV_IPV6_NEIGHBOR_ADDRESS:
-                if(sub_length != BGP_NLRI_TLV_IPV6_NEIGHBOR_ADDRESS){
+                if(sub_length != BGP_NLRI_TLV_LEN_IPV6_NEIGHBOR_ADDRESS){
                     expert_add_info_format(pinfo, tlv_tree, &ei_bgp_ls_error,
                                            "Unexpected IPv6 Neighbor Address TLV's length (%u), it must be %u bytes!",
-                                           sub_length, BGP_NLRI_TLV_IPV6_NEIGHBOR_ADDRESS);
+                                           sub_length, BGP_NLRI_TLV_LEN_IPV6_NEIGHBOR_ADDRESS);
                     return -1;
                 }
                 tlv_sub_item = proto_tree_add_item(tlv_tree,


### PR DESCRIPTION
Fix the following issue:

> [Expert Info (Error/Protocol): Unexpected IPv6 Neighbor Address TLV's length (16), it must be 262 bytes!]

Fixes: 10345a6b2e ("From Miroslav Miklus via https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=9504 Enhance BGP dissector : bgp-ls dissector (draft-ietf-idr-ls-distribution-04)")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>