### PR TITLE
Adding PLDM dissector

### DIFF
--- a/epan/dissectors/CMakeLists.txt
+++ b/epan/dissectors/CMakeLists.txt
@@ -162,6 +162,12 @@ set(CLEAN_ASN1_DISSECTOR_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-pkixproxy.c
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-pkixqualified.c
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-pkixtsp.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm-base.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm-bios.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm-fru.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm-oem.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm-platform.c
+	${CMAKE_CURRENT_SOURCE_DIR}/packet-pldm.c
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-pres.c
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-q932.c
 	${CMAKE_CURRENT_SOURCE_DIR}/packet-q932-ros.c

--- a/epan/dissectors/packet-pldm-base.c
+++ b/epan/dissectors/packet-pldm-base.c
@@ -1,0 +1,407 @@
+#include "packet-pldm-base.h"
+#include <config.h>
+#include <epan/packet.h>
+#include <stdint.h>
+
+static int pldmTA[8] = {0};
+static int pldmTI[32][8] = {0};
+
+static const value_string pldmBaseCmd[] = {{1, "Set TID"},
+                                           {2, "Get TID"},
+                                           {3, "Get PLDM Version"},
+                                           {4, "Get PLDM Types"},
+                                           {5, "GetPLDMCommands"},
+                                           {6, "SelectPLDMVersion"},
+                                           {7, "NegotiateTranferParameters"},
+                                           {8, "Multipart Send"},
+                                           {9, "Multipart Receive"},
+                                           {0, NULL}};
+
+static const value_string specNames[] = {
+    {0, "PLDM Messaging and Discovery"},
+    {1, "PLDM for SMBIOS"},
+    {2, "PLDM Platform Monitoring and Control"},
+    {3, "PLDM for BIOS Control and Configuration"},
+    {4, "PLDM for FRU Data"},
+    {5, "PLDM for Firmware Update"},
+    {6, "PLDM for Redfish Device Enablement"},
+    {63, "OEM Specific"},
+    {0, NULL}};
+
+static const val64_string pldmTypes[] = {
+    {0, "base"},      {1, "smbios"}, {2, "platform"}, {3, "bios"}, {4, "fru"},
+    {5, "fw_update"}, {6, "rde"},    {63, "oem"},     {0, NULL}};
+
+static const value_string pldmPlatformCmds[] = {{4, "SetEventReceiver"},
+                                                {10, "PlatformEventMessage"},
+                                                {17, "GetSensorReading"},
+                                                {33, "GetStateSensorReadings"},
+                                                {49, "SetNumericEffecterValue"},
+                                                {50, "GetNumericEffecterValue"},
+                                                {57, "SetStateEffecterStates"},
+                                                {81, "GetPDR"},
+                                                {0, NULL}};
+
+static const value_string pldmFruCmds[] = {{1, "GetFRURecordTableMetadata"},
+                                           {2, "GetFRURecordTable"},
+                                           {4, "GetFRURecordByOption"},
+                                           {0, NULL}};
+
+static const value_string pldmBIOScmd[] = {
+    {1, "GetBIOSTable"},
+    {2, "SetBIOSTable"},
+    {7, "SetBIOSAttributeCurrentValue"},
+    {8, "GetBIOSAttributeCurrentValueByHandle"},
+    {12, "GetDateTime"},
+    {13, "SetDateTime"},
+    {0, NULL}};
+
+static const value_string pldmOEMCmds[] = {{1, "GetFileTable"},
+                                           {4, "ReadFile"},
+                                           {5, "WriteFile"},
+                                           {6, "ReadFileInToMemory"},
+                                           {7, "WriteFileFromMemory"},
+                                           {8, "ReadFileByTypeIntoMemory"},
+                                           {9, "WriteFileByTypeFromMemory"},
+                                           {10, "NewFileAvailable"},
+                                           {11, "ReadFileByType"},
+                                           {12, "WriteFileByType"},
+                                           {13, "FileAck"},
+                                           {0, NULL}};
+
+static const value_string transferOperationFlags[] = {
+    {0, "GetNextPart"}, {1, "GetFirstPart"}, {0, NULL}};
+
+static const value_string transferFlags[] = {
+    {1, "Start"}, {2, "Middle"}, {4, "End"}, {5, "StartAndEnd"}, {0, NULL}};
+
+static const value_string completion_codes[] = {
+    {0x0, "Success"},
+    {0x1, "Error"},
+    {0x2, "Invalid Data"},
+    {0x3, "Invalid Length"},
+    {0x4, "Not Ready"},
+    {0x5, "Unsupported PLDM command"},
+    {0x20, "Invalid PLDM type"},
+    {0, NULL}};
+
+static int proto_pldm_base = -1;
+static int hf_pldm_cmd = -1;
+static int hf_pldmBIOScmd = -1;
+static int hf_pldmFruCmds = -1;
+static int hf_pldmPlatformCmds = -1;
+static int hf_pldmOEMCmds = -1;
+static int hf_pldm_version = -1;
+static int hf_pldmSpec8 = -1;
+static int hf_pldm_types = -1;
+static int hf_TransferOperationFlag = -1;
+static int hf_NextDataTransferHandle = -1;
+static int hf_TransferFlag = -1;
+static int hf_DataTransferHandle = -1;
+static int hf_TIDValue = -1;
+static int hf_completion_code = -1;
+
+static int print_version_field(guint8 bcd, char *buffer, size_t buffer_size) {
+  int v;
+  if (bcd == 0xff)
+    return 0;
+  if ((bcd & 0xf0) == 0xf0) {
+    v = bcd & 0x0f;
+    return snprintf(buffer, buffer_size, "%d", v);
+  }
+  v = ((bcd >> 4) * 10) + (bcd & 0x0f);
+  return snprintf(buffer, buffer_size, "%02d", v);
+}
+
+#define POINTER_MOVE(rc, buffer, buffer_size)                                  \
+  do {                                                                         \
+    if (rc < 0)                                                                \
+      return;                                                                  \
+    if ((size_t)rc >= buffer_size)                                             \
+      return;                                                                  \
+    buffer += rc;                                                              \
+    buffer_size -= rc;                                                         \
+  } while (0);
+
+void ver2str(tvbuff_t *tvb, int offset, char *buf_ptr, size_t buffer_size) {
+  int rc;
+  guint8 major = tvb_get_guint8(tvb, offset);
+  offset += 1;
+  guint8 minor = tvb_get_guint8(tvb, offset);
+  offset += 1;
+  guint8 update = tvb_get_guint8(tvb, offset);
+  offset += 1;
+  guint8 alpha = tvb_get_guint8(tvb, offset);
+
+  // major, minor and update fields are all BCD encoded
+  if (major != 0xff) {
+    rc = print_version_field(major, buf_ptr, buffer_size);
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+    rc = snprintf(buf_ptr, buffer_size, ".");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  } else {
+    rc = snprintf(buf_ptr, buffer_size, "-");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  }
+  if (minor != 0xff) {
+    rc = print_version_field(minor, buf_ptr, buffer_size);
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  } else {
+    rc = snprintf(buf_ptr, buffer_size, "-");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  }
+  if (update != 0xff) {
+    rc = snprintf(buf_ptr, buffer_size, ".");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+    rc = print_version_field(update, buf_ptr, buffer_size);
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  } else {
+    rc = snprintf(buf_ptr, buffer_size, "-");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  }
+  if (alpha != 0x00) {
+    rc = snprintf(buf_ptr, buffer_size, "%c", alpha);
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  } else {
+    rc = snprintf(buf_ptr, buffer_size, "-");
+    POINTER_MOVE(rc, buf_ptr, buffer_size);
+  }
+}
+
+int dissect_base(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *p_tree,
+                 void *data) {
+  struct packet_data *d = (struct packet_data *)data;
+  static uint8_t pldmT = -1;
+
+  guint8 instID = d->instance_id;
+  guint8 request = d->direction;
+
+  guint8 offset = 0;
+  guint8 pldm_cmd = tvb_get_guint8(tvb, offset);
+  proto_tree_add_item(p_tree, hf_pldm_cmd, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+  offset += 1;
+  if (!request) {
+    proto_tree_add_item(p_tree, hf_completion_code, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    guint8 completion_code = tvb_get_guint8(tvb, offset);
+    if (completion_code)
+      return tvb_captured_length(tvb);
+    offset += 1;
+  }
+
+  switch (pldm_cmd) {
+  case 01: // SetTID
+    if (request) {
+      proto_tree_add_item(p_tree, hf_TIDValue, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 02: // GetTID
+    if (!request) {
+      proto_tree_add_item(p_tree, hf_TIDValue, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 03: // GetPLDMVersion
+    if (request) {
+      proto_tree_add_item(p_tree, hf_DataTransferHandle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_TransferOperationFlag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_pldmSpec8, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_NextDataTransferHandle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_TransferFlag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      char buffer[10];
+      ver2str(tvb, offset, buffer, 10);
+      proto_tree_add_string(p_tree, hf_pldm_version, tvb, offset, 4, buffer);
+    }
+    break;
+  case 04: // GetPLDMTypes
+    if (!request) {
+      guint64 types = tvb_get_letoh64(tvb, offset);
+      guint64 flag_bit, i;
+      flag_bit = 1;
+      for (i = 0; i < 64; i++, flag_bit <<= 1) {
+        if (types & flag_bit) {
+          if (i > 7 && i / 8 == 0)
+            offset += 1;
+          proto_tree_add_uint64(p_tree, hf_pldm_types, tvb, offset, 64, i);
+        }
+      }
+    }
+    break;
+  case 05: // GetPLDMCommands
+    if (request) {
+      pldmT = tvb_get_guint8(tvb, offset);
+      if (pldmT == 63)
+        pldmT = 7;
+      pldmTA[pldmT] = 1;
+      pldmTI[instID][pldmT] = 1;
+      proto_tree_add_item(p_tree, hf_pldmSpec8, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      char buffer[10];
+      ver2str(tvb, offset, buffer, 10);
+      proto_tree_add_string(p_tree, hf_pldm_version, tvb, offset, 4, buffer);
+    } else if (!request) {
+      if (pldmTI[instID][3] == 1) {
+        guint16 byte = tvb_get_letohs(tvb, offset);
+        guint16 flag_bit = 1;
+        for (guint8 i = 0; i < 16; i++, flag_bit <<= 1) {
+          if (i > 7 && i % 8 == 0)
+            offset += 1;
+          if (byte & flag_bit) {
+            proto_tree_add_uint(p_tree, hf_pldmBIOScmd, tvb, offset, 1, i);
+          }
+        }
+      }
+      if (pldmTI[instID][0] == 1) {
+        offset += 1;
+        guint8 byte = tvb_get_guint8(tvb, offset);
+        guint8 flag_bit = 1;
+        for (guint8 i = 0; i < 8; i++, flag_bit <<= 1) {
+          if (byte & flag_bit) {
+            proto_tree_add_uint(p_tree, hf_pldm_cmd, tvb, offset, 1, i);
+          }
+        }
+      }
+      if (pldmTI[instID][4] == 1) {
+        offset += 1;
+        guint64 byte = tvb_get_letoh64(tvb, offset);
+        guint64 flag_bit = 1;
+        for (guint8 i = 0; i < 64; i++, flag_bit <<= 1) {
+          if (i > 7 && i % 8 == 0)
+            offset += 1;
+          if (byte & flag_bit) {
+            proto_tree_add_uint(p_tree, hf_pldmFruCmds, tvb, offset, 1, i);
+          }
+        }
+      }
+      if (pldmTI[instID][2] == 1) {
+        offset += 1;
+        guint64 b1 = tvb_get_letoh64(tvb, offset);
+        guint64 b2 = tvb_get_letoh64(tvb, offset + 8);
+        guint64 b3 = tvb_get_letoh64(tvb, offset + 16);
+        guint64 b4 = tvb_get_letoh64(tvb, offset + 24);
+        guint64 byt[4];
+        byt[0] = b1;
+        byt[1] = b2;
+        byt[2] = b3;
+        byt[3] = b4;
+        guint64 flag_bit = 1;
+        for (guint8 i = 0; i < 88; i++, flag_bit <<= 1) {
+          if (i == 64) {
+            flag_bit = 1;
+          }
+          int j = i / 64;
+          if (i > 7 && i % 8 == 0)
+            offset += 1;
+          guint64 byte = byt[j];
+          if (byte & flag_bit) {
+            proto_tree_add_uint(p_tree, hf_pldmPlatformCmds, tvb, offset, 1, i);
+          }
+        }
+      }
+      if (pldmTI[instID][7] == 1) {
+        offset += 1;
+        guint64 b1 = tvb_get_letoh64(tvb, offset);
+        guint64 b2 = tvb_get_letoh64(tvb, offset + 8);
+        guint64 b3 = tvb_get_letoh64(tvb, offset + 16);
+        guint64 b4 = tvb_get_letoh64(tvb, offset + 24);
+        guint64 byt[4];
+        byt[0] = b1;
+        byt[1] = b2;
+        byt[2] = b3;
+        byt[3] = b4;
+        guint64 flag_bit = 1;
+        for (guint8 i = 0; i < 16; i++, flag_bit <<= 1) {
+          if (i == 64 || i == 128 || i == 192) {
+            flag_bit = 1;
+          }
+          int j = i / 64;
+          if (i > 7 && i % 8 == 0) {
+            offset += 1;
+          }
+          guint64 byte = byt[j];
+          if (byte & flag_bit) {
+            proto_tree_add_uint(p_tree, hf_pldmOEMCmds, tvb, offset, 1, i);
+          }
+        }
+      }
+    }
+    break;
+  default:
+    col_append_fstr(pinfo->cinfo, COL_INFO, "Invalid PLDM command");
+    g_print("Invalid PLDM cmd\n");
+    break;
+  }
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_base(void) {
+  static hf_register_info hf[] = {
+      {&hf_TIDValue,
+       {"TID", "pldm.base.TID", FT_UINT8, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_DataTransferHandle,
+       {"Data Transfer Handle", "pldm.base.transferHandle", FT_UINT32, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_TransferOperationFlag,
+       {"Transfer Operation Flag", "pldm.base.operationFlag", FT_UINT8,
+        BASE_DEC, VALS(transferOperationFlags), 0x0, NULL, HFILL}},
+      {&hf_NextDataTransferHandle,
+       {"NextDataTransferHandle", "pldm.base.nextDataTransferHandle", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_TransferFlag,
+       {"Transfer Flag", "pldm.base.transferFlag", FT_UINT8, BASE_DEC,
+        VALS(transferFlags), 0x0, NULL, HFILL}},
+      {&hf_pldmSpec8,
+       {"PLDMType requested", "pldm.base.ty", FT_UINT8, BASE_DEC,
+        VALS(specNames), 0x0, NULL, HFILL}},
+      {&hf_pldm_version,
+       {"PLDM Version", "pldm.base.version", FT_STRING, BASE_NONE, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_pldm_types,
+       {"pldm type supported :", "pldm.base.type", FT_UINT64,
+        BASE_DEC | BASE_VAL64_STRING, VALS64(pldmTypes), 0x0, NULL, HFILL}},
+      {&hf_pldmBIOScmd,
+       {"pldm type supported :", "pldm.base.xyz", FT_UINT8, BASE_DEC,
+        VALS(pldmBIOScmd), 0x0, NULL, HFILL}},
+      {&hf_pldmFruCmds,
+       {"pldm type supported :", "pldm.base.fru", FT_UINT8, BASE_DEC,
+        VALS(pldmFruCmds), 0x0, NULL, HFILL}},
+      {&hf_pldmPlatformCmds,
+       {"pldm type supported :", "pldm.base.platform", FT_UINT8, BASE_DEC,
+        VALS(pldmPlatformCmds), 0x0, NULL, HFILL}},
+      {&hf_pldmOEMCmds,
+       {"pldm type supported :", "pldm.base.oem", FT_UINT8, BASE_DEC,
+        VALS(pldmOEMCmds), 0x0, NULL, HFILL}},
+      {&hf_pldm_cmd,
+       {"PLDM Command", "pldm.cmd", FT_UINT8, BASE_HEX, VALS(pldmBaseCmd), 0x0,
+        NULL, HFILL}},
+      {&hf_completion_code,
+       {"Completion Code", "pldm.cc", FT_UINT8, BASE_DEC,
+        VALS(completion_codes), 0x0, NULL, HFILL}},
+  };
+
+  proto_pldm_base = proto_register_protocol("PLDM base Protocol", /* name */
+                                            "PLDM_B",   /* short_name  */
+                                            "pldm.base" /* filter_name */
+  );
+  proto_register_field_array(proto_pldm_base, hf, array_length(hf));
+}
+
+void proto_reg_handoff_base(void) {
+  static dissector_handle_t base_handle;
+
+  base_handle = create_dissector_handle(dissect_base, proto_pldm_base);
+  dissector_add_uint("wtap_encap", 147, base_handle);
+  dissector_add_uint("pldm.type", PLDM_DISCOVERY, base_handle);
+}

--- a/epan/dissectors/packet-pldm-base.h
+++ b/epan/dissectors/packet-pldm-base.h
@@ -1,0 +1,24 @@
+#include "config.h"
+#include <epan/packet.h>
+
+#include <stdint.h>
+#ifndef PACKET_PLDM_H
+#define PACKET_PLDM_H
+
+enum PLDMType {
+  PLDM_DISCOVERY,
+  PLDM_SMBIOS,
+  PLDM_PLATFORM,
+  PLDM_BIOS,
+  PLDM_FRU,
+  PLDM_FIRMWARE_UPDATE,
+  PLDM_REDFISH,
+  PLDM_OEM = 63
+};
+
+struct packet_data {
+  guint8 direction;
+  guint8 instance_id;
+};
+
+#endif

--- a/epan/dissectors/packet-pldm-bios.c
+++ b/epan/dissectors/packet-pldm-bios.c
@@ -1,0 +1,952 @@
+#include "packet-pldm-base.h"
+#include <stdint.h>
+
+// BIOS table
+static int proto_pldm_bios = -1;
+static int hf_pldm_cmd = -1;
+static int hf_completion_code = -1;
+static int hf_bios_data_handle = -1;
+static int hf_bios_transfer_op_flag = -1;
+static int hf_bios_table_type = -1;
+static int hf_bios_next_data_handle = -1;
+static int hf_bios_transfer_flag = -1;
+static int hf_bios_attr_handle = -1;
+static int hf_bios_attr_type = -1;
+static int hf_bios_attr_name_handle = -1;
+static int hf_bios_enumer_num_pos_values = -1;
+static int hf_bios_enumer_pos_value_str_hndl = -1;
+static int hf_bios_enumer_num_default_values = -1;
+static int hf_bios_enumer_default_value_str_hndl = -1;
+static int hf_bios_attr_table_pad_bytes = -1;
+static int hf_bios_attr_table_checksum = -1;
+static int hf_bios_str_handle = -1;
+static int hf_bios_str_len = -1;
+static int hf_bios_str = -1;
+static int hf_bios_string_type = -1;
+static int hf_bios_min_str_len = -1;
+static int hf_bios_max_str_len = -1;
+static int hf_bios_def_str_len = -1;
+static int hf_bios_def_str = -1;
+static int hf_bios_int_lower_bound = -1;
+static int hf_bios_int_upper_bound = -1;
+static int hf_bios_int_scalar_inc = -1;
+static int hf_bios_int_def_val = -1;
+static int hf_bios_boot_config_type = -1;
+static int hf_bios_fail_through_modes = -1;
+static int hf_bios_min_num_boot_src = -1;
+static int hf_bios_max_num_boot_src = -1;
+static int hf_bios_pos_num_boot_src = -1;
+static int hf_bios_src_str_hndl = -1;
+static int hf_bios_col_name_str_hndl = -1;
+static int hf_bios_max_num_attr = -1;
+static int hf_bios_col_type = -1;
+static int hf_bios_num_pos_config = -1;
+static int hf_bios_pos_config_str_hndl = -1;
+static int hf_bios_enumer_num_cur_values = -1;
+static int hf_bios_enumer_cur_value_str_hndl = -1;
+static int hf_bios_cur_str_len = -1;
+static int hf_bios_cur_str = -1;
+static int hf_bios_cur_pass_len = -1;
+static int hf_bios_cur_pass = -1;
+static int hf_bios_cur_val = -1;
+static int hf_bios_num_boot_src = -1;
+static int hf_bios_boot_src_str_hndl = -1;
+static int hf_bios_num_attr = -1;
+static int hf_bios_attr_hndl = -1;
+static int hf_bios_cur_config_set_str_hndl = -1;
+static int hf_bios_enumer_num_pen_values = -1;
+static int hf_bios_enumer_pen_value_str_hndl = -1;
+static int hf_bios_pen_str_len = -1;
+static int hf_bios_pen_str = -1;
+static int hf_bios_pen_pass_len = -1;
+static int hf_bios_pen_pass = -1;
+static int hf_bios_pen_val = -1;
+static int hf_bios_config_set_str_hndl = -1;
+static int hf_bios_pass_type = -1;
+static int hf_bios_min_pass_len = -1;
+static int hf_bios_max_pass_len = -1;
+static int hf_bios_def_pass_len = -1;
+static int hf_bios_def_pass = -1;
+static int hf_bios_num_pen_boot_src = -1;
+
+// Date and Time
+static int hf_pldm_time = -1;
+static int hf_pldm_date = -1;
+guint8 table_type = 0;
+
+static const value_string pldm_cmds[] = {
+    {0x01, "GetBIOSTable"},
+    {0x02, "SetBIOSTable"},
+    {0x03, "UpdateBIOSTable"},
+    {0x04, "GetBIOSTableTags"},
+    {0x05, "SetBIOSTableTags"},
+    {0x06, "AcceptBIOSAttributesPending"},
+    {0x07, "SetBIOSAttributeCurrentValue"},
+    {0x08, "GetBIOSAttributeCurrentValueByHandle"},
+    {0x09, "GetBIOSAttributePendingValueByHandle"},
+    {0x0a, "GetBIOSAttributeCurrentValueByType"},
+    {0x0b, "GetBIOSAttributePendingValueByType"},
+    {0x0c, "GetDateTime"},
+    {0x0d, "SetDateTime"},
+    {0x0e, "GetBIOSStringTableStringType"},
+    {0x0f, "SetBIOSStringTableStringType"},
+    {0, NULL}};
+
+static const value_string completion_codes[] = {
+    {0x0, "Success"},
+    {0x1, "Error"},
+    {0x2, "Invalid Data"},
+    {0x3, "Invalid Length"},
+    {0x4, "Not Ready"},
+    {0x5, "Unsupported PLDM command"},
+    {0x20, "Invalid PLDM type"},
+    {0x80, "Invalid data transfer handle"},
+    {0x81, "Invalid transfer operation flag"},
+    {0x82, "Invalid transfer flag"},
+    {0x83, "BIOS table unavailable"},
+    {0x84, "Invalid BIOS table integrity check"},
+    {0x85, "Invalid BIOS table"},
+    {0x86, "BIOS table tag unavailable"},
+    {0x87, "Invalid BIOS table tag type"},
+    {0x88, "Invalid BIOS attr handle"},
+    {0x89, "Invalid BIOS attr type"},
+    {0x8a, "No date time info available"},
+    {0x8b, "Invalid string type"},
+    {0, NULL}};
+
+static const value_string bios_table_types[] = {
+    {0x0, "BIOS String Table"},
+    {0x1, "BIOS Attribute Table"},
+    {0x2, "BIOS Attribute Value Table"},
+    {0x3, "BIOS Attribute Pending Value Table"},
+    {0, NULL}};
+
+static const value_string transfer_op_flags[] = {
+    {0x0, "Get Next Part"}, {0x1, "Get First Part"}, {0, NULL}};
+
+static const value_string transfer_flags[] = {{0x1, "Start"},
+                                              {0x2, "Middle"},
+                                              {0x4, "End"},
+                                              {0x5, "Start and End"},
+                                              {0, NULL}};
+
+static const value_string bios_attribute_type[] = {
+    {0x0, "BIOSEnumeration"},
+    {0x1, "BIOSString"},
+    {0x2, "BIOSPassword"},
+    {0x3, "BIOSInteger"},
+    {0x4, "BIOSBootConfigSetting"},
+    {0x5, "BIOSCollection"},
+    {0x6, "BIOSConfigSet"},
+    {0x80, "BIOSEnumerationReadOnly"},
+    {0x81, "BIOSStringRaedOnly"},
+    {0x82, "BIOSPasswordReadOnly"},
+    {0x83, "BIOSIntegerReadOnly"},
+    {0x84, "BiosPasswordReadOnly"},
+    {0x85, "BIOSCollectionReadOnly"},
+    {0x86, "BIOSConfigSetReadOnly"}};
+
+#define BCD44_TO_DEC(x) ((((x)&0xf0) >> 4) * 10 + ((x)&0x0f))
+
+void dissect_bios_string_table(tvbuff_t *tvb, proto_tree *p_tree,
+                               guint16 *offset, packet_info *pinfo) {
+  guint16 len = tvb_reported_length(tvb);
+  guint16 rem_bytes = len - 27;
+  guint16 str_len = 0;
+  int num_pad_bytes = 0;
+  while (rem_bytes >= 8) {
+    proto_tree_add_item(p_tree, hf_bios_str_handle, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    str_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+    proto_tree_add_item(p_tree, hf_bios_str_len, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    proto_tree_add_item(p_tree, hf_bios_str, tvb, *offset, str_len, ENC_ASCII);
+    proto_item_append_text(
+        p_tree, ": %s",
+        tvb_get_string_enc(pinfo->pool, tvb, *offset, str_len, ENC_ASCII));
+    *offset += str_len;
+    rem_bytes = rem_bytes - 4 - str_len;
+    str_len = 0;
+  }
+  proto_tree_add_item(p_tree, hf_bios_attr_table_pad_bytes, tvb, *offset,
+                      num_pad_bytes, ENC_LITTLE_ENDIAN);
+  *offset += num_pad_bytes;
+  proto_tree_add_item(p_tree, hf_bios_attr_table_checksum, tvb, *offset, 4,
+                      ENC_LITTLE_ENDIAN);
+  return;
+}
+
+void dissect_bios_attribute_table(tvbuff_t *tvb, proto_tree *p_tree,
+                                  guint16 *offset, packet_info *pinfo) {
+  guint16 len = tvb_reported_length(tvb);
+  guint16 rem_bytes = len - 27;
+  int len_attr_fields = 0;
+  guint16 num_values = 0;
+  guint8 attr_type = 0;
+  int num_pad_bytes = 0;
+  while (rem_bytes >= 8) {
+    proto_tree_add_item(p_tree, hf_bios_attr_handle, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    attr_type = tvb_get_guint8(tvb, *offset);
+    proto_tree_add_item(p_tree, hf_bios_attr_type, tvb, *offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 1;
+    proto_tree_add_item(p_tree, hf_bios_attr_name_handle, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    if (attr_type == 0 || attr_type == 128) {
+      num_values = tvb_get_guint8(tvb, *offset);
+      proto_tree_add_item(p_tree, hf_bios_enumer_num_pos_values, tvb, *offset,
+                          1, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_enumer_pos_value_str_hndl, tvb,
+                            *offset, 2, ENC_LITTLE_ENDIAN);
+        *offset += 2;
+        len_attr_fields += 2;
+        num_values--;
+      }
+      num_values = tvb_get_guint8(tvb, *offset);
+      proto_tree_add_item(p_tree, hf_bios_enumer_num_default_values, tvb,
+                          *offset, 1, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_enumer_default_value_str_hndl, tvb,
+                            *offset, 1, ENC_LITTLE_ENDIAN);
+        *offset += 1;
+        len_attr_fields += 1;
+        num_values--;
+      }
+    } else if (attr_type == 1 || attr_type == 129) {
+      proto_tree_add_item(p_tree, hf_bios_string_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_min_str_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_max_str_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_def_str_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      guint16 def_str_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      if (def_str_len != 0) {
+        proto_tree_add_item(p_tree, hf_bios_def_str, tvb, *offset, def_str_len,
+                            ENC_ASCII);
+        proto_item_append_text(p_tree, ": %s",
+                               tvb_get_string_enc(pinfo->pool, tvb, *offset,
+                                                  def_str_len, ENC_ASCII));
+        *offset += def_str_len;
+        len_attr_fields += def_str_len;
+      }
+    } else if (attr_type == 2 || attr_type == 130) {
+      proto_tree_add_item(p_tree, hf_bios_pass_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_min_pass_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_max_pass_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      guint8 def_pass_len = tvb_get_guint8(tvb, *offset);
+      proto_tree_add_item(p_tree, hf_bios_def_pass_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      if (def_pass_len != 0) {
+        proto_tree_add_item(p_tree, hf_bios_def_pass, tvb, *offset,
+                            hf_bios_def_str_len, ENC_LITTLE_ENDIAN);
+        *offset += def_pass_len;
+        len_attr_fields += def_pass_len;
+      }
+    } else if (attr_type == 3 || attr_type == 131) {
+      proto_tree_add_item(p_tree, hf_bios_int_lower_bound, tvb, *offset, 8,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 8;
+      len_attr_fields += 8;
+      proto_tree_add_item(p_tree, hf_bios_int_upper_bound, tvb, *offset, 8,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 8;
+      len_attr_fields += 8;
+      proto_tree_add_item(p_tree, hf_bios_int_scalar_inc, tvb, *offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 4;
+      len_attr_fields += 4;
+      proto_tree_add_item(p_tree, hf_bios_int_def_val, tvb, *offset, 8,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 8;
+      len_attr_fields += 8;
+    } else if (attr_type == 4 || attr_type == 132) {
+      proto_tree_add_item(p_tree, hf_bios_boot_config_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_fail_through_modes, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_min_num_boot_src, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_max_num_boot_src, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_pos_num_boot_src, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_src_str_hndl, tvb, *offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        *offset += 2;
+        len_attr_fields += 2;
+        num_values--;
+      }
+    } else if (attr_type == 5 || attr_type == 133) {
+      proto_tree_add_item(p_tree, hf_bios_col_name_str_hndl, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_max_num_attr, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_col_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+    } else if (attr_type == 6 || attr_type == 134) {
+      proto_tree_add_item(p_tree, hf_bios_num_pos_config, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_pos_config_str_hndl, tvb, *offset,
+                            2, ENC_LITTLE_ENDIAN);
+        *offset += 2;
+        len_attr_fields += 2;
+        num_values--;
+      }
+    }
+    if (rem_bytes == 8)
+      break;
+    else if (rem_bytes < len_attr_fields + 5) {
+      num_pad_bytes = rem_bytes % 4;
+      rem_bytes = 8;
+    } else
+      rem_bytes = rem_bytes - 5 - len_attr_fields;
+    len_attr_fields = 0;
+  }
+  proto_tree_add_item(p_tree, hf_bios_attr_table_pad_bytes, tvb, *offset,
+                      num_pad_bytes, ENC_LITTLE_ENDIAN);
+  *offset += num_pad_bytes;
+  proto_tree_add_item(p_tree, hf_bios_attr_table_checksum, tvb, *offset, 4,
+                      ENC_LITTLE_ENDIAN);
+  return;
+}
+
+void dissect_bios_attribute_val_table(tvbuff_t *tvb, proto_tree *p_tree,
+                                      guint16 *offset) {
+  guint16 len = tvb_reported_length(tvb);
+  guint16 rem_bytes = len - 27;
+  int len_attr_fields = 0;
+  guint16 num_values = 0;
+  guint8 attr_type = 0;
+  int num_pad_bytes = 0;
+  while (rem_bytes >= 8 && rem_bytes > 0) {
+    proto_tree_add_item(p_tree, hf_bios_attr_handle, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    attr_type = tvb_get_guint8(tvb, *offset);
+    proto_tree_add_item(p_tree, hf_bios_attr_type, tvb, *offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 1;
+    if (attr_type == 0 || attr_type == 128) {
+      num_values = tvb_get_guint8(tvb, *offset);
+      proto_tree_add_item(p_tree, hf_bios_enumer_num_cur_values, tvb, *offset,
+                          1, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_enumer_cur_value_str_hndl, tvb,
+                            *offset, 1, ENC_LITTLE_ENDIAN);
+        *offset += 1;
+        len_attr_fields += 1;
+        num_values--;
+      }
+    } else if (attr_type == 1 || attr_type == 129) {
+      proto_tree_add_item(p_tree, hf_bios_cur_str_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      guint16 cur_str_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      proto_tree_add_item(p_tree, hf_bios_cur_str, tvb, *offset,
+                          hf_bios_cur_str_len, ENC_LITTLE_ENDIAN);
+      *offset += cur_str_len;
+      len_attr_fields += cur_str_len;
+    } else if (attr_type == 2 || attr_type == 130) {
+      proto_tree_add_item(p_tree, hf_bios_cur_pass_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      guint16 cur_pass_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      proto_tree_add_item(p_tree, hf_bios_cur_pass, tvb, *offset,
+                          hf_bios_cur_pass_len, ENC_LITTLE_ENDIAN);
+      *offset += cur_pass_len;
+      len_attr_fields += cur_pass_len;
+    } else if (attr_type == 3 || attr_type == 131) {
+      proto_tree_add_item(p_tree, hf_bios_cur_val, tvb, *offset, 8,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 8;
+      len_attr_fields += 8;
+    } else if (attr_type == 4 || attr_type == 132) {
+      proto_tree_add_item(p_tree, hf_bios_boot_config_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_fail_through_modes, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_num_boot_src, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values >= 0) {
+        proto_tree_add_item(p_tree, hf_bios_boot_src_str_hndl, tvb, *offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        *offset += 1;
+        len_attr_fields += 1;
+        num_values--;
+      }
+    } else if (attr_type == 5 || attr_type == 133) {
+      proto_tree_add_item(p_tree, hf_bios_num_attr, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_attr_hndl, tvb, *offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        *offset += 2;
+        len_attr_fields += 2;
+        num_values--;
+      }
+    } else if (attr_type == 6 || attr_type == 134) {
+      proto_tree_add_item(p_tree, hf_bios_cur_config_set_str_hndl, tvb,
+                          (*offset), 1, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+    }
+    if (rem_bytes == 8)
+      break;
+    else if (rem_bytes < len_attr_fields + 3) {
+      num_pad_bytes = rem_bytes % 4;
+      rem_bytes = 8;
+    } else
+      rem_bytes = rem_bytes - 3 - len_attr_fields;
+    len_attr_fields = 0;
+  }
+  proto_tree_add_item(p_tree, hf_bios_attr_table_pad_bytes, tvb, *offset,
+                      num_pad_bytes, ENC_LITTLE_ENDIAN);
+  *offset += num_pad_bytes;
+  proto_tree_add_item(p_tree, hf_bios_attr_table_checksum, tvb, *offset, 4,
+                      ENC_LITTLE_ENDIAN);
+  return;
+}
+
+void dissect_bios_attribute_pending_val_table(tvbuff_t *tvb, proto_tree *p_tree,
+                                              guint16(*offset)) {
+  guint16 len = tvb_reported_length(tvb);
+  guint16 rem_bytes = len - 27;
+  int len_attr_fields = 0;
+  guint16 num_values = 0;
+  guint8 attr_type = 0;
+  int num_pad_bytes = 0;
+  while (rem_bytes >= 8 && rem_bytes > 0) {
+    proto_tree_add_item(p_tree, hf_bios_attr_handle, tvb, *offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 2;
+    attr_type = tvb_get_guint8(tvb, *offset);
+    proto_tree_add_item(p_tree, hf_bios_attr_type, tvb, *offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    *offset += 1;
+    if (attr_type == 0) {
+      num_values = tvb_get_guint8(tvb, *offset);
+      proto_tree_add_item(p_tree, hf_bios_enumer_num_pen_values, tvb, *offset,
+                          1, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_enumer_pen_value_str_hndl, tvb,
+                            *offset, 1, ENC_LITTLE_ENDIAN);
+        *offset += 1;
+        len_attr_fields += 1;
+        num_values--;
+      }
+    } else if (attr_type == 1) {
+      guint16 pen_str_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      proto_tree_add_item(p_tree, hf_bios_pen_str_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_pen_str, tvb, *offset,
+                          hf_bios_cur_str_len, ENC_LITTLE_ENDIAN);
+      *offset += pen_str_len;
+      len_attr_fields += pen_str_len;
+    } else if (attr_type == 2) {
+      guint16 pen_pass_len = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      proto_tree_add_item(p_tree, hf_bios_pen_pass_len, tvb, *offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 2;
+      len_attr_fields += 2;
+      proto_tree_add_item(p_tree, hf_bios_pen_pass, tvb, *offset,
+                          hf_bios_cur_pass_len, ENC_LITTLE_ENDIAN);
+      *offset += pen_pass_len;
+      len_attr_fields += pen_pass_len;
+    } else if (attr_type == 3) {
+      proto_tree_add_item(p_tree, hf_bios_pen_val, tvb, *offset, 8,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 8;
+      len_attr_fields += 8;
+    } else if (attr_type == 4) {
+      proto_tree_add_item(p_tree, hf_bios_boot_config_type, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_fail_through_modes, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      proto_tree_add_item(p_tree, hf_bios_num_pen_boot_src, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_boot_src_str_hndl, tvb, *offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        *offset += 1;
+        len_attr_fields += 1;
+        num_values--;
+      }
+    } else if (attr_type == 5 || attr_type == 133) {
+      proto_tree_add_item(p_tree, hf_bios_num_attr, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      num_values = tvb_get_guint16(tvb, *offset, ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+      while (num_values > 0) {
+        proto_tree_add_item(p_tree, hf_bios_attr_hndl, tvb, *offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        *offset += 2;
+        len_attr_fields += 2;
+        num_values--;
+      }
+    } else if (attr_type == 6) {
+      proto_tree_add_item(p_tree, hf_bios_config_set_str_hndl, tvb, *offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      *offset += 1;
+      len_attr_fields += 1;
+    }
+    if (rem_bytes == 8)
+      break;
+    else if (rem_bytes < len_attr_fields + 3) {
+      num_pad_bytes = rem_bytes % 4;
+      rem_bytes = 8;
+    } else
+      rem_bytes = rem_bytes - 3 - len_attr_fields;
+    len_attr_fields = 0;
+  }
+  proto_tree_add_item(p_tree, hf_bios_attr_table_pad_bytes, tvb, *offset,
+                      num_pad_bytes, ENC_LITTLE_ENDIAN);
+  *offset += num_pad_bytes;
+  proto_tree_add_item(p_tree, hf_bios_attr_table_checksum, tvb, *offset, 4,
+                      ENC_LITTLE_ENDIAN);
+  return;
+}
+
+int dissect_bios(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *p_tree,
+                 void *data) {
+  struct packet_data *d = (struct packet_data *)data;
+  guint8 request = d->direction;
+  guint8 pldm_cmd = tvb_get_guint8(tvb, 0);
+  guint16 offset = 0;
+  guint8 hour, min, sec;
+  proto_tree_add_item(p_tree, hf_pldm_cmd, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+  offset += 1;
+  if (!request) {
+    proto_tree_add_item(p_tree, hf_completion_code, tvb, 1, 1,
+                        ENC_LITTLE_ENDIAN);
+    guint8 completion_code = tvb_get_guint8(tvb, offset);
+    if (completion_code)
+      return tvb_captured_length(tvb);
+    offset += 1;
+  }
+  switch (pldm_cmd) {
+  case 0x1: // Get BIOS Table
+    if (request) {
+      proto_tree_add_item(p_tree, hf_bios_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_op_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_bios_table_type, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      table_type = tvb_get_guint8(tvb, offset);
+    } else {
+      proto_tree_add_item(p_tree, hf_bios_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      if (table_type == 0) {
+        dissect_bios_string_table(tvb, p_tree, &offset, pinfo);
+      } else if (table_type == 1) {
+        dissect_bios_attribute_table(tvb, p_tree, &offset, pinfo);
+      } else if (table_type == 2) {
+        dissect_bios_attribute_val_table(tvb, p_tree, &offset);
+      } else if (table_type == 3) {
+        dissect_bios_attribute_pending_val_table(tvb, p_tree, &offset);
+      }
+    }
+    break;
+  case 0x02: // Set BIOS Table
+    if (request) {
+      proto_tree_add_item(p_tree, hf_bios_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_bios_table_type, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      table_type = tvb_get_guint8(tvb, offset);
+      offset += 1;
+      if (table_type == 0) {
+        dissect_bios_string_table(tvb, p_tree, &offset, pinfo);
+      } else if (table_type == 1) {
+        dissect_bios_attribute_table(tvb, p_tree, &offset, pinfo);
+      } else if (table_type == 2) {
+        dissect_bios_attribute_val_table(tvb, p_tree, &offset);
+      }
+    } else {
+      proto_tree_add_item(p_tree, hf_bios_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x07: // Set BIOS Attribute Current Value
+    if (request) {
+      proto_tree_add_item(p_tree, hf_bios_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_bios_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x08: // Get BIOS Attribute Current Value by Handle
+    if (request) {
+      proto_tree_add_item(p_tree, hf_bios_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_op_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_bios_attr_handle, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_bios_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_bios_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      dissect_bios_attribute_val_table(tvb, p_tree, &offset);
+    }
+    break;
+  case 0x0c: // Get Date and Time
+    if (!request) {
+      sec = BCD44_TO_DEC(tvb_get_guint8(tvb, offset));
+      min = BCD44_TO_DEC(tvb_get_guint8(tvb, offset + 1));
+      hour = BCD44_TO_DEC(tvb_get_guint8(tvb, offset + 2));
+      if (hour > 23 || min > 59 || sec > 59)
+        return -1;
+      char time[9];
+      snprintf(time, 9, "%02d:%02d:%02d", hour, min, sec);
+      proto_tree_add_string(p_tree, hf_pldm_time, tvb, offset, 3, time);
+      offset += 3;
+      guint8 day = BCD44_TO_DEC(tvb_get_guint8(tvb, offset));
+      guint8 month = BCD44_TO_DEC(tvb_get_guint8(tvb, offset + 1));
+      guint16 year = BCD44_TO_DEC(tvb_get_guint8(tvb, offset + 3)) * 100 +
+                     BCD44_TO_DEC(tvb_get_guint8(tvb, offset + 2));
+      if (day > 31 || day < 1 || month > 12 || month < 1)
+        return -1;
+
+      char date[11];
+      snprintf(date, 11, "%02d/%02d/%04d", day, month, year);
+      proto_tree_add_string(p_tree, hf_pldm_date, tvb, offset, 4, date);
+    }
+    break;
+  default:
+    col_append_fstr(pinfo->cinfo, COL_INFO,
+                    "Unsupported or Invalid PLDM command");
+    g_print("Invalid PLDM bios cmd %x \n", pldm_cmd);
+    break;
+  }
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_bios(void) {
+  static hf_register_info hf[] = {
+      {&hf_bios_data_handle,
+       {"Data transfer handle", "pldm.bios.table.handle", FT_UINT32, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_transfer_op_flag,
+       {"Data transfer operation flag", "pldm.bios.table.opflag", FT_UINT8,
+        BASE_HEX, VALS(transfer_op_flags), 0x0, NULL, HFILL}},
+      {&hf_bios_table_type,
+       {"BIOS table type", "pldm.bios.table.type", FT_UINT8, BASE_HEX,
+        VALS(bios_table_types), 0x0, NULL, HFILL}},
+      {&hf_bios_next_data_handle,
+       {"Next data transfer handle", "pldm.bios.table.nexthandle", FT_UINT32,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_transfer_flag,
+       {"Data transfer operation flag", "pldm.bios.table.flag", FT_UINT8,
+        BASE_HEX, VALS(transfer_flags), 0x0, NULL, HFILL}},
+      {&hf_bios_attr_handle,
+       {"Attribute handle", "pldm.bios.attr.handle", FT_UINT16, BASE_HEX, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_bios_attr_type,
+       {"Attribute type", "pldm.bios.attr.type", FT_UINT8, BASE_HEX,
+        VALS(bios_attribute_type), 0x0, NULL, HFILL}},
+      {&hf_bios_attr_name_handle,
+       {"BIOS attribute name handle", "bios.attr.name.handle", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_enumer_num_pos_values,
+       {"BIOS enumeration number of possible values",
+        "bios.enumer.num.pos.values", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_pos_value_str_hndl,
+       {"BIOS enumeration possible value string handle",
+        "bios.enumer.pos.value.str.hndl", FT_UINT16, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_num_default_values,
+       {"BIOS enumeration number of default values",
+        "bios.enumer.num.default.values", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_default_value_str_hndl,
+       {"BIOS enumeration default value string handle",
+        "bios.enumer.default.value.str.hndl", FT_UINT8, BASE_HEX, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_bios_attr_table_pad_bytes,
+       {"BIOS attribute table pad bytes", "bios.attribute.pad.bytes", FT_UINT64,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_attr_table_checksum,
+       {"BIOS attribute table checksum", "bios.attr.table.checksum", FT_UINT32,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_str_handle,
+       {"BIOS attribute string handle", "bios.str.handle", FT_UINT16, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_str_len,
+       {"BIOS attribute string length", "bios.str.len", FT_UINT16, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_str,
+       {"BIOS attribute string", "bios.str", FT_STRING, BASE_NONE, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_bios_string_type,
+       {"BIOS attribute string type", "bios.string.type", FT_UINT8, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_min_str_len,
+       {"BIOS attribute min string length", "bios.min.str.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_max_str_len,
+       {"BIOS attribute max string length", "bios.max.str.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_def_str_len,
+       {"BIOS attribute default string length", "bios.def.str.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_def_str,
+       {"BIOS attribute default string", "bios.def.str", FT_STRING, BASE_NONE,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pass_type,
+       {"BIOS attribute password type", "bios.pass.type", FT_UINT8, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_min_pass_len,
+       {"BIOS attribute min password length", "bios.min.pass.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_max_pass_len,
+       {"BIOS attribute max password length", "bios.max.pass.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_def_pass_len,
+       {"BIOS attribute default password length", "bios.def.pass.len",
+        FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_def_pass,
+       {"BIOS attribute default password", "bios.def.pass", FT_UINT16, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_int_lower_bound,
+       {"BIOS attribute integer lower bound", "bios.int.lower.bound", FT_UINT64,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_int_upper_bound,
+       {"BIOS attribute integer upper bound", "bios.int.upper.bound", FT_UINT64,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_int_scalar_inc,
+       {"BIOS attribute integer scalar inc", "bios.int.scalar.inc", FT_UINT32,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_int_def_val,
+       {"BIOS attribute integer default value", "bios.int.def.val", FT_UINT64,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_boot_config_type,
+       {"BIOS boot config type", "bios.boot.config.type", FT_UINT8, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_fail_through_modes,
+       {"BIOS attribute suuported and ordered fail through modes",
+        "bios.fail.through.modes", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_min_num_boot_src,
+       {"BIOS attribute minimum number of boot source settings",
+        "bios.min.num.boot.src", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_max_num_boot_src,
+       {"BIOS attribute maximum number of boot source settings",
+        "bios.max.num.boot.src", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pos_num_boot_src,
+       {"BIOS attribute number of possible boot source settings",
+        "bios.pos.num.boot.src", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_src_str_hndl,
+       {"BIOS attribute possible boot source string handle",
+        "bios.src.str.hndl", FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_col_name_str_hndl,
+       {"BIOS attribute collection name string handle",
+        "bios.col.name.str.hndl", FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_max_num_attr,
+       {"BIOS attribute max number of attributes", "bios.max.num.attr",
+        FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_col_type,
+       {"BIOS attribute collection type", "bios.col.type", FT_UINT16, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_num_pos_config,
+       {"BIOS attribute number of possible BIOS config", "bios.num.pos.config",
+        FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pos_config_str_hndl,
+       {"BIOS attribute possible BIOS config string handle",
+        "bios.pos.config.str.hndl", FT_UINT16, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_num_cur_values,
+       {"BIOS attribute enumeration number of current values",
+        "bios.enumer.num.cur.values", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_cur_value_str_hndl,
+       {"BIOS attribute enumeration current value string handle",
+        "bios.enumer.cur.value.str.hndl", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_cur_str_len,
+       {"BIOS attribute current string length", "bios.cur.str.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_cur_str,
+       {"BIOS attribute current string", "bios.cur.str", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_cur_pass_len,
+       {"BIOS attribute current password length", "bios.cur.pass.len",
+        FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_cur_pass,
+       {"BIOS attribute current password", "bios.cur.pass", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_cur_val,
+       {"BIOS attribute current value", "bios.cur.val", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_num_boot_src,
+       {"BIOS attribute number of boot source settings", "bios.num.boot.src",
+        FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_boot_src_str_hndl,
+       {"BIOS attribute boot source setting string handle",
+        "bios.boot.src.str.hndl", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_num_attr,
+       {"BIOS collection number of attributes", "bios.num.attr", FT_UINT8,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_attr_hndl,
+       {"BIOS collection attribute handle", "bios.attr.hndl", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_cur_config_set_str_hndl,
+       {"BIOS cuurent config set string handle index",
+        "bios.cur.config.set.str.hndl", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_num_pen_values,
+       {"BIOS attribute enumeration pending of current values",
+        "bios.enumer.num.pen.values", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_enumer_pen_value_str_hndl,
+       {"BIOS attribute enumeration pending value string handle",
+        "bios.enumer.pen.value.str.hndl", FT_UINT8, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_bios_pen_str_len,
+       {"BIOS attribute pending string length", "bios.pen.str.len", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pen_str,
+       {"BIOS attribute pending string", "bios.pen.str", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pen_pass_len,
+       {"BIOS attribute pending password length", "bios.pen.pass.len",
+        FT_UINT16, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pen_pass,
+       {"BIOS attribute pending password", "bios.pen.pass", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_pen_val,
+       {"BIOS attribute pending value", "bios.pen.val", FT_UINT64, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_num_pen_boot_src,
+       {"BIOS attribute number of pending boot source settings",
+        "bios.num.pen.boot.src", FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_bios_config_set_str_hndl,
+       {"BIOS config set string handle index", "bios.config.set.str.hndl",
+        FT_UINT8, BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_pldm_time,
+       {"Time", "pldm.bios.time", FT_STRING, BASE_NONE, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_pldm_date,
+       {"Date", "pldm.bios.date", FT_STRING, BASE_NONE, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_pldm_cmd,
+       {"PLDM Command Type", "pldm.cmd", FT_UINT8, BASE_HEX, VALS(pldm_cmds),
+        0x0, NULL, HFILL}},
+      {&hf_completion_code,
+       {"Completion Code", "pldm.cc", FT_UINT8, BASE_DEC,
+        VALS(completion_codes), 0x0, NULL, HFILL}},
+
+  };
+
+  proto_pldm_bios =
+      proto_register_protocol("PLDM BIOS Control and Configuration", /* name */
+                              "PLDM_bios", /* short_name  */
+                              "pldm.bios"  /* filter_name */
+      );
+  proto_register_field_array(proto_pldm_bios, hf, array_length(hf));
+}
+
+void proto_reg_handoff_bios(void) {
+  static dissector_handle_t bios_handle;
+
+  bios_handle = create_dissector_handle(dissect_bios, proto_pldm_bios);
+  dissector_add_uint("pldm.type", PLDM_BIOS, bios_handle);
+}

--- a/epan/dissectors/packet-pldm-fru.c
+++ b/epan/dissectors/packet-pldm-fru.c
@@ -1,0 +1,355 @@
+#include "packet-pldm-base.h"
+#include <stdint.h>
+
+static int proto_pldm_fru = -1;
+static int hf_pldm_cmd = -1;
+static int hf_completion_code = -1;
+
+static int hf_fru_major_ver = -1;
+static int hf_fru_minor_ver = -1;
+static int hf_fru_table_max_size = -1;
+static int hf_fru_table_length = -1;
+static int hf_fru_num_record_identifiers = -1;
+static int hf_fru_num_records = -1;
+static int hf_fru_table_crc = -1;
+
+static int hf_fru_data_handle = -1;
+static int hf_fru_transfer_op_flag = -1;
+static int hf_fru_next_data_handle = -1;
+static int hf_fru_transfer_flag = -1;
+
+// FRU Record fields
+static int hf_fru_record_id = -1;
+static int hf_fru_record_type = -1;
+static int hf_fru_record_num_fields = -1;
+static int hf_fru_record_encoding = -1;
+static int hf_fru_record_field_type = -1;
+static int hf_fru_record_field_type_oem = -1;
+static int hf_fru_record_field_len = -1;
+static int hf_fru_record_field_value = -1;
+static int hf_fru_record_field_value_bytes = -1;
+static int hf_fru_record_field_value_uint16 = -1;
+static int hf_fru_record_field_value_string = -1;
+static int hf_fru_record_crc = -1;
+
+static const value_string pldm_cmds[] = {{0x01, "GetFRURecordTableMetadata"},
+                                         {0x02, "GetFRURecordTable"},
+                                         {0x03, "SetFRURecordTable"},
+                                         {0x04, "GetFRURecordByOption"},
+                                         {0, NULL}};
+
+static const value_string completion_codes[] = {
+    {0x0, "Success"},
+    {0x1, "Error"},
+    {0x2, "Invalid Data"},
+    {0x3, "Invalid Length"},
+    {0x4, "Not Ready"},
+    {0x5, "Unsupported PLDM command"},
+    {0x20, "Invalid PLDM type"},
+    {0x80, "Invalid data transfer handle"},
+    {0x81, "Invalid transfer operation flag"},
+    {0x82, "Invalid transfer flag"},
+    {0x83, "No FRU table metadata"},
+    {0x84, "Invalid data integrity check"},
+    {0x85, "Fru data table unavailable"},
+    {0, NULL}};
+
+static const value_string transfer_op_flags[] = {
+    {0x0, "Get Next Part"}, {0x1, "Get First Part"}, {0, NULL}};
+
+static const value_string transfer_flags[] = {{0x1, "Start"},
+                                              {0x2, "Middle"},
+                                              {0x4, "End"},
+                                              {0x5, "Start and End"},
+                                              {0, NULL}};
+
+static const value_string record_encoding[] = {{1, "ASCII"},    {2, "UTF8"},
+                                               {3, "UTF16"},    {4, "UTF16-LE"},
+                                               {5, "UTF16-BE"}, {0, NULL}};
+
+static const value_string record_types[] = {
+    {1, "General FRU Record"}, {254, "OEM FRU Record"}, {0, NULL}};
+
+static const value_string field_types_general[] = {
+    {0x0, "Reserved"},
+    {0x1, "Chassis Type"},
+    {0x2, "Model"},
+    {0x3, "Part Number"},
+    {0x4, "Serial Number"},
+    {0x5, "Manufactuer"},
+    {0x6, "Manufacture Date"},
+    {0x7, "Vendor"},
+    {0x8, "Name"},
+    {0x9, "SKU"},
+    {0xa, "Version"},
+    {0xb, "Asset Tag"},
+    {0xc, "Description"},
+    {0xd, "Engineering Change Level"},
+    {0xe, "Other Information"},
+    {0xf, "Vendor IANA"},
+    {0, NULL}};
+
+guint16 parse_fru_record_table(tvbuff_t *tvb, packet_info *pinfo,
+                               proto_tree *p_tree, guint16 offset) {
+  guint8 min_size = 8, field_len = 0, num_fields = 0, encoding = 0, record_type;
+  guint16 bytes_left = tvb_reported_length(tvb) - offset;
+  while (bytes_left >= min_size) {
+    // parse a FRU Record Data
+    proto_tree_add_item(p_tree, hf_fru_record_id, tvb, offset, 2,
+                        ENC_LITTLE_ENDIAN);
+    offset += 2;
+    record_type = tvb_get_guint8(tvb, offset);
+    proto_tree_add_item(p_tree, hf_fru_record_type, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    offset += 1;
+    num_fields = tvb_get_guint8(tvb, offset);
+    proto_tree_add_item(p_tree, hf_fru_record_num_fields, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    offset += 1;
+    encoding = tvb_get_guint8(tvb, offset);
+    proto_tree_add_item(p_tree, hf_fru_record_encoding, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    offset += 1;
+
+    for (guint8 i = 0; i < num_fields; i++) {
+      if (record_type == 254) { // OEM
+        proto_tree_add_item(p_tree, hf_fru_record_field_type_oem, tvb, offset,
+                            1, ENC_LITTLE_ENDIAN);
+        offset += 1;
+        field_len = tvb_get_guint8(tvb, offset);
+        proto_tree_add_item(p_tree, hf_fru_record_field_len, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        offset += 1;
+        guint8 *test2 =
+            (guint8 *)tvb_memdup(wmem_packet_scope(), tvb, offset, field_len);
+        proto_tree_add_bytes(p_tree, hf_fru_record_field_value_bytes, tvb,
+                             offset, field_len, test2);
+        offset += field_len;
+      } else if (record_type == 1) { // General
+        proto_tree_add_item(p_tree, hf_fru_record_field_type, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        offset += 1;
+        field_len = tvb_get_guint8(tvb, offset);
+        proto_tree_add_item(p_tree, hf_fru_record_field_len, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        offset += 1;
+
+        switch (encoding) {
+        case 0x1:
+          proto_tree_add_item(p_tree, hf_fru_record_field_value_string, tvb,
+                              offset, field_len, ENC_ASCII);
+          break;
+        case 0x2:
+          proto_tree_add_item(p_tree, hf_fru_record_field_value, tvb, offset,
+                              field_len, ENC_UTF_8);
+          break;
+        case 0x3:
+          proto_tree_add_item(p_tree, hf_fru_record_field_value_uint16, tvb,
+                              offset, field_len, ENC_UTF_16);
+          break;
+        case 0x4:
+          proto_tree_add_item(p_tree, hf_fru_record_field_value_uint16, tvb,
+                              offset, field_len,
+                              ENC_UTF_16 | ENC_LITTLE_ENDIAN);
+          break;
+        case 0x5:
+          proto_tree_add_item(p_tree, hf_fru_record_field_value_uint16, tvb,
+                              offset, field_len, ENC_UTF_16 | ENC_BIG_ENDIAN);
+          break;
+        default:
+          col_append_fstr(pinfo->cinfo, COL_INFO,
+                          "Unsupported or invalid FRU record encoding");
+          break;
+        }
+        offset += field_len;
+      }
+    }
+    bytes_left = tvb_reported_length(tvb) - offset;
+  }
+  return offset;
+}
+
+int dissect_fru(tvbuff_t *tvb, packet_info *pinfo, proto_tree *p_tree,
+                void *data) {
+  struct packet_data *d = (struct packet_data *)data;
+  guint8 request = d->direction;
+  guint16 offset = 0;
+  guint8 pldm_cmd = tvb_get_guint8(tvb, offset);
+  guint8 padding = 0;
+  proto_tree_add_item(p_tree, hf_pldm_cmd, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+  offset += 1;
+  if (!request) {
+    proto_tree_add_item(p_tree, hf_completion_code, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    guint8 completion_code = tvb_get_guint8(tvb, offset);
+    if (completion_code)
+      return tvb_captured_length(tvb);
+    offset += 1;
+  }
+  switch (pldm_cmd) {
+  case 0x01: // Get Fru record table metadata
+    if (!request) {
+      proto_tree_add_item(p_tree, hf_fru_major_ver, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_fru_minor_ver, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_fru_table_max_size, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_fru_table_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_fru_num_record_identifiers, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_fru_num_records, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_fru_table_crc, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x02: // Get Fru record table
+    if (request) {
+      proto_tree_add_item(p_tree, hf_fru_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_fru_transfer_op_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_fru_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_fru_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      offset = parse_fru_record_table(tvb, pinfo, p_tree, offset);
+      if (tvb_captured_length(tvb) != offset)
+        col_append_fstr(pinfo->cinfo, COL_INFO,
+                        "Unexpected bytes at end of FRU table");
+    }
+    break;
+  case 0x03: // Set Fru record table
+    if (request) {
+      proto_tree_add_item(p_tree, hf_fru_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_fru_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      offset = parse_fru_record_table(tvb, pinfo, p_tree, offset);
+      if (tvb_captured_length(tvb) != offset) {
+        padding = tvb_captured_length(tvb) - offset - 4;
+        offset += padding;
+        proto_tree_add_item(p_tree, hf_fru_record_crc, tvb, offset, 4,
+                            ENC_LITTLE_ENDIAN);
+      }
+    } else {
+      proto_tree_add_item(p_tree, hf_fru_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  default:
+    col_append_fstr(pinfo->cinfo, COL_INFO,
+                    "Unsupported or Invalid PLDM command");
+    g_print("Invalid PLDM fru cmd %x \n", pldm_cmd);
+    break;
+  }
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_fru(void) {
+  static hf_register_info hf[] = {
+      {&hf_pldm_cmd,
+       {"PLDM Command Type", "pldm.cmd", FT_UINT8, BASE_HEX, VALS(pldm_cmds),
+        0x0, NULL, HFILL}},
+      {&hf_completion_code,
+       {"Completion Code", "pldm.cc", FT_UINT8, BASE_DEC,
+        VALS(completion_codes), 0x0, NULL, HFILL}},
+      {&hf_fru_major_ver,
+       {"FRU Major version", "pldm.fru.ver.major", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_fru_minor_ver,
+       {"FRU Minor version", "pldm.fru.ver.minor", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_fru_table_max_size,
+       {"FRU Maximum table size", "pldm.fru.table.max", FT_UINT32, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_table_length,
+       {"FRU Table length", "pldm.fru.table.len", FT_UINT32, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_fru_num_record_identifiers,
+       {"Total number of record set identifiers", "pldm.fru.num_identifiers",
+        FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_num_records,
+       {"Total number of records in table", "pldm.fru.table.num_records",
+        FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_table_crc,
+       {"FRU Table CRC", "pldm.fru.table.crc", FT_UINT32, BASE_DEC, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_fru_data_handle,
+       {"FRU Data transfer handle", "pldm.fru.table.handle", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_transfer_op_flag,
+       {"FRU Data transfer operation flag", "pldm.fru.table.opflag", FT_UINT8,
+        BASE_DEC, VALS(transfer_op_flags), 0x0, NULL, HFILL}},
+      {&hf_fru_next_data_handle,
+       {"FRU Next data transfer handle", "pldm.fru.table.nexthandle", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_transfer_flag,
+       {"FRU Data transfer flag", "pldm.fru.table.flag", FT_UINT8, BASE_DEC,
+        VALS(transfer_flags), 0x0, NULL, HFILL}},
+      // FRU Record fields
+      {&hf_fru_record_id,
+       {"FRU Record Set Identifier", "pldm.fru.record.id", FT_UINT16, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_type,
+       {"FRU Record Type", "pldm.fru.record.type", FT_UINT8, BASE_DEC,
+        VALS(record_types), 0x0, NULL, HFILL}},
+      {&hf_fru_record_num_fields,
+       {"Number of FRU fields", "pldm.fru.record.num_fields", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_encoding,
+       {"FRU Record Encoding", "pldm.fru.record.encoding", FT_UINT8, BASE_DEC,
+        VALS(record_encoding), 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_type,
+       {"FRU Record Field Type", "pldm.fru.record.field_type", FT_UINT8,
+        BASE_DEC, VALS(field_types_general), 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_type_oem,
+       {"FRU Record Field Type", "pldm.fru.record.field_type", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_len,
+       {"FRU Record Field Length", "pldm.fru.record.field_length", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_value,
+       {"FRU Record Field Value", "pldm.fru.record.field_value", FT_UINT8,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_value_bytes,
+       {"FRU Record Field Value", "pldm.fru.record.field_value", FT_BYTES,
+        SEP_SPACE, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_value_uint16,
+       {"FRU Record Field Value", "pldm.fru.record.field_value", FT_UINT16,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_field_value_string,
+       {"FRU Record Field Value", "pldm.fru.record.field_value", FT_STRING,
+        BASE_NONE, NULL, 0x0, NULL, HFILL}},
+      {&hf_fru_record_crc,
+       {"FRU Record CRC32 (Unchecked)", "pldm.fru.record.crc", FT_UINT32,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+  };
+
+  proto_pldm_fru = proto_register_protocol("PLDM FRU Data Protocol", /* name */
+                                           "PLDM_FRU", /* short_name  */
+                                           "pldm.fru"  /* filter_name */
+  );
+  proto_register_field_array(proto_pldm_fru, hf, array_length(hf));
+}
+
+void proto_reg_handoff_fru(void) {
+  static dissector_handle_t fru_handle;
+
+  fru_handle = create_dissector_handle(dissect_fru, proto_pldm_fru);
+  dissector_add_uint("pldm.type", PLDM_FRU, fru_handle);
+}

--- a/epan/dissectors/packet-pldm-oem.c
+++ b/epan/dissectors/packet-pldm-oem.c
@@ -1,0 +1,282 @@
+#include "packet-pldm-base.h"
+#include <stdint.h>
+
+static int proto_pldm_oem = -1;
+static int hf_pldm_cmd = -1;
+static int hf_completion_code = -1;
+static int hf_file_data_handle = -1;
+static int hf_file_transfer_op_flag = -1;
+static int hf_file_table_type = -1;
+static int hf_file_next_data_handle = -1;
+static int hf_file_transfer_flag = -1;
+
+static int hf_file_type = -1;
+static int hf_file_name_handle = -1;
+static int hf_file_handle = -1;
+static int hf_file_offset = -1;
+static int hf_file_length = -1;
+static int hf_file_length_64 = -1;
+static int hf_file_address = -1;
+
+static const value_string pldm_cmds[] = {{0x01, "GetFileTable"},
+                                         {0x02, "SetFileTable"},
+                                         {0x03, "UpdateFileTable"},
+                                         {0x04, "ReadFile"},
+                                         {0x05, "WriteFile"},
+                                         {0x06, "ReadFileIntoMemory"},
+                                         {0x07, "WriteFileFromMemory"},
+                                         {0x08, "ReadFileByTypeIntoMemory"},
+                                         {0x09, "WriteFileByTypeFromMemory"},
+                                         {0x0a, "NewFileAvailable"},
+                                         {0x0b, "ReadFileByType"},
+                                         {0x0c, "WriteFileByType"},
+                                         {0x0d, "FileAck"},
+                                         {0x0e, "NewFileAvailableWithMetadata"},
+                                         {0x0f, "FileAckWithMetadata"},
+                                         {0, NULL}};
+
+static const value_string completion_codes[] = {
+    {0x0, "Success"},
+    {0x1, "Error"},
+    {0x2, "Invalid Data"},
+    {0x3, "Invalid Length"},
+    {0x4, "Not Ready"},
+    {0x5, "Unsupported PLDM command"},
+    {0x20, "Invalid PLDM type"},
+    {0x80, "Invalid data transfer handle"},
+    {0x81, "Invalid transfer operation flag"},
+    {0x82, "Invalid transfer flag"},
+    {0x83, "File table unavailable"},
+    {0x84, "Invalid file table integrity check"},
+    {0x85, "Invalid file table"},
+    {0x86, "Invalid file handle"},
+    {0x87, "Data out of range"},
+    {0x88, "Read only"},
+    {0x89, "Invalid file type"},
+    {0x8a, "Error file discarded"},
+    {0x8b, "Full file discarded"},
+    {0, NULL}};
+
+static const value_string file_table_types[] = {
+    {0x0, "File Attribute Table"},
+    {0x1, "OEM File Attribute Table"},
+    {0, NULL}};
+
+static const value_string transfer_op_flags[] = {
+    {0x0, "Get Next Part"}, {0x1, "Get First Part"}, {0, NULL}};
+
+static const value_string transfer_flags[] = {{0x1, "Start"},
+                                              {0x2, "Middle"},
+                                              {0x4, "End"},
+                                              {0x5, "Start and End"},
+                                              {0, NULL}};
+
+int dissect_oem(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *p_tree,
+                void *data) {
+  struct packet_data *d = (struct packet_data *)data;
+  guint8 request = d->direction;
+  guint8 offset = 0;
+  guint8 pldm_cmd = tvb_get_guint8(tvb, offset);
+  proto_tree_add_item(p_tree, hf_pldm_cmd, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+  offset += 1;
+  if (!request) {
+    proto_tree_add_item(p_tree, hf_completion_code, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    guint8 completion_code = tvb_get_guint8(tvb, offset);
+    if (completion_code)
+      return tvb_captured_length(tvb);
+    offset += 1;
+  }
+  switch (pldm_cmd) {
+  case 0x1: // Get File Table
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_transfer_op_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_file_table_type, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x4: // Read File
+  case 0x5: // Write File
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_name_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_offset, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x6: // Read File into memory
+  case 0x7: // Write File from memory
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_name_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_offset, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_address, tvb, offset, 8,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x8: // Read File by type into memory
+  case 0x9: // Write File by type into memory
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_type, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_file_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_offset, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_address, tvb, offset, 8,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0xa: // New File Available
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_type, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_file_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length_64, tvb, offset, 8,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+    }
+    break;
+  case 0xb: // Read File by Type
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_type, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_file_name_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_offset, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0xc: // Write File by Type
+    if (request) {
+      proto_tree_add_item(p_tree, hf_file_type, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_file_name_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_offset, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_file_length, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  default:
+    col_append_fstr(pinfo->cinfo, COL_INFO,
+                    "Unsupported or Invalid PLDM command");
+    g_print("Invalid PLDM oem cmd %x \n", pldm_cmd);
+    break;
+  }
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_oem(void) {
+  static hf_register_info hf[] = {
+      {&hf_pldm_cmd,
+       {"PLDM Command Type", "pldm.cmd", FT_UINT8, BASE_HEX, VALS(pldm_cmds),
+        0x0, NULL, HFILL}},
+      {&hf_completion_code,
+       {"Completion Code", "pldm.cc", FT_UINT8, BASE_DEC,
+        VALS(completion_codes), 0x0, NULL, HFILL}},
+      {&hf_file_data_handle,
+       {"Data transfer handle", "pldm.file.table.handle", FT_UINT32, BASE_HEX,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_file_transfer_op_flag,
+       {"Data transfer operation flag", "pldm.file.table.opflag", FT_UINT8,
+        BASE_HEX, VALS(transfer_op_flags), 0x0, NULL, HFILL}},
+      {&hf_file_table_type,
+       {"File table type", "pldm.oem.table.type", FT_UINT8, BASE_HEX,
+        VALS(file_table_types), 0x0, NULL, HFILL}},
+      {&hf_file_next_data_handle,
+       {"Next data transfer handle", "pldm.oem.table.nexthandle", FT_UINT32,
+        BASE_HEX, NULL, 0x0, NULL, HFILL}},
+      {&hf_file_transfer_flag,
+       {"Data transfer operation flag", "pldm.file.table.flag", FT_UINT8,
+        BASE_HEX, VALS(transfer_flags), 0x0, NULL, HFILL}},
+      {&hf_file_type,
+       {"File type", "pldm.file.type", FT_UINT16, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_file_name_handle,
+       {"File name handle", "pldm.file.name_handle", FT_UINT32, BASE_HEX, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_file_handle,
+       {"File handle", "pldm.file.handle", FT_UINT16, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_file_offset,
+       {"File offset", "pldm.file.offset", FT_UINT32, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_file_length,
+       {"File length", "pldm.file.length", FT_UINT32, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_file_length_64,
+       {"File length", "pldm.file.length", FT_UINT64, BASE_HEX, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_file_address,
+       {"File address", "pldm.file.address", FT_UINT64, BASE_HEX, NULL, 0x0,
+        NULL, HFILL}},
+  };
+
+  proto_pldm_oem = proto_register_protocol("PLDM OEM Protocol", /* name */
+                                           "PLDM_OEM", /* short_name  */
+                                           "pldm.oem"  /* filter_name */
+  );
+  proto_register_field_array(proto_pldm_oem, hf, array_length(hf));
+}
+
+void proto_reg_handoff_oem(void) {
+  static dissector_handle_t oem_handle;
+
+  oem_handle = create_dissector_handle(dissect_oem, proto_pldm_oem);
+  dissector_add_uint("pldm.type", PLDM_OEM, oem_handle);
+}

--- a/epan/dissectors/packet-pldm-platform.c
+++ b/epan/dissectors/packet-pldm-platform.c
@@ -1,0 +1,624 @@
+#include "packet-pldm-base.h"
+#include <stdint.h>
+
+static int proto_pldm_platform = -1;
+static int hf_completion_code = -1;
+static int hf_pldm_cmd = -1;
+
+/* Event messages */
+static int hf_format_version = -1;
+static int hf_TID = -1;
+static int hf_event_class = -1;
+static int hf_result_status = -1;
+static int hf_sensor_id = -1;
+static int hf_sensor_event_class = -1;
+static int hf_sensor_offset = -1;
+static int hf_event_state = -1;
+static int hf_event_prev_state = -1;
+static int hf_sensor_data_size = -1;
+static int hf_sensor_value_u8 = -1;
+static int hf_sensor_value_s8 = -1;
+static int hf_sensor_value_u16 = -1;
+static int hf_sensor_value_s16 = -1;
+static int hf_sensor_value_u32 = -1;
+static int hf_sensor_value_s32 = -1;
+static int hf_sensor_op_state = -1;
+static int hf_sensor_prev_op_state = -1;
+static int hf_sensor_rearm = -1;
+static int hf_sensor_composite_count = -1;
+static int hf_heartbeat_format_ver = -1;
+static int hf_heartbeat_sequence_num = -1;
+static int hf_pdr_data_format = -1;
+static int hf_pdr_num_change_recs = -1;
+
+/* Set Event Receiver */
+static int hf_event_message_global = -1;
+static int hf_transport_protocol_type = -1;
+static int hf_event_receiver_addr_info = -1;
+static int hf_heartbeat_timer = -1;
+
+/* Effecter */
+static int hf_effecter_id = -1;
+static int hf_effecter_count = -1;
+static int hf_effecter_datasize = -1;
+static int hf_effecter_value_u8 = -1;
+static int hf_effecter_value_s8 = -1;
+static int hf_effecter_value_u16 = -1;
+static int hf_effecter_value_s16 = -1;
+static int hf_effecter_value_u32 = -1;
+static int hf_effecter_value_s32 = -1;
+
+/* PDR */
+static int hf_record_handle = -1;
+static int hf_data_handle = -1;
+static int hf_transfer_op_flag = -1;
+static int hf_request_count = -1;
+static int hf_record_change_num = -1;
+static int hf_next_record_handle = -1;
+static int hf_next_data_handle = -1;
+static int hf_transfer_flag = -1;
+static int hf_response_count = -1;
+static int hf_transfer_crc = -1;
+
+static const value_string pldm_cmds[] = {
+    // Terminus commands
+    {0x01, "SetTID"},
+    {0x02, "GetTID"},
+    {0x03, "GetTerminusUID"},
+    {0x04, "SetEventReceiver"},
+    {0x05, "GetEventReceiver"},
+    {0x0A, "PlatformEventMessage"},
+    {0x0B, "PollForPlatformEventMessage"},
+    {0x0C, "EventMessageSupported"},
+    {0x0D, "EventMessageBufferSize "},
+    // Numeric Sensor commands
+    {0x10, "SetNumericSensorEnable"},
+    {0x11, "GetSensorReading"},
+    {0x12, "GetSensorThresholds"},
+    {0x13, "SetSensorThresholds"},
+    {0x14, "RestoreSensorThresholds"},
+    {0x15, "GetSensorHysteresis"},
+    {0x16, "SetSensorHysteresis"},
+    {0x17, "InitNumericSensor"},
+    // State Sensor commands
+    {0x20, "SetStateSensorEnables"},
+    {0x21, "GetStateSensorReadings"},
+    {0x22, "InitStateSensor"},
+    // PLDM Effecter commands
+    {0x30, "SetNumericEffecterEnable"},
+    {0x31, "SetNumericEffecterValue"},
+    {0x32, "GetNumericEffecterValue"},
+    {0x38, "SetStateEffecterEnables"},
+    {0x39, "SetStateEffecterStates"},
+    {0x3A, "GetStateEffecterStates"},
+    // PLDM Event Log commands
+    {0x40, "GetPLDMEventLogInfo"},
+    {0x41, "EnablePLDMEventLogging"},
+    {0x42, "ClearPLDMEventLog"},
+    {0x43, "GetPLDMEventLogTimestamp"},
+    {0x44, "SetPLDMEventLogTimestamp"},
+    {0x45, "ReadPLDMEventLog"},
+    {0x46, "GetPLDMEventLogPolicyInfo"},
+    {0x47, "SetPLDMEventLogPolicy"},
+    {0x48, "FindPLDMEventLogEntry"},
+    // PDR Repository commands
+    {0x50, "GetPDRRepositoryInfo"},
+    {0x51, "GetPDR"},
+    {0x52, "FindPDR"},
+    {0x53, "GetPDRRepositorySignature"},
+    {0x58, "RunInitAgent"},
+    {0, NULL}};
+
+static const value_string event_classes[] = {
+    {0, "Sensor Event"},
+    {1, "Effector Event"},
+    {2, "Redfish Task Event"},
+    {3, "Redfish Message Event"},
+    {4, "Pldm PDR Repository Change Event"},
+    {5, "Pldm Message Poll Event"},
+    {6, "Heartbeat Timer Elapsed Event"},
+    {0, NULL}
+    // other OEM ones
+};
+
+static const value_string sensor_event_classes[] = {{0, "Sensor Operational"},
+                                                    {1, "State Sensor State"},
+                                                    {2, "Numeric Sensor State"},
+                                                    {0, NULL}};
+
+static const value_string completion_codes[] = {
+    {0x0, "Success"},
+    {0x1, "Error"},
+    {0x2, "Invalid Data"},
+    {0x3, "Invalid Length"},
+    {0x4, "Not Ready"},
+    {0x5, "Unsupported PLDM command"},
+    {0x20, "Invalid PLDM type"},
+    {0, NULL}
+    // TODO check if types of messages have same error codes (eg effecter, pdr
+    // repo)
+};
+
+static const value_string result_status[] = {
+    {0, "No Logging"}, {1, "Logging disabled"},
+    {2, "Log Full"},   {3, "Accepted for logging"},
+    {4, "Logged"},     {5, "Logging Rejected"},
+    {0, NULL}};
+
+static const value_string event_message_global_enable[] = {
+    {0, "Disable"},
+    {1, "Enable Async"},
+    {2, "Enable Polling"},
+    {3, "Enable Async Keep Alive"},
+    {0, NULL}};
+
+static const value_string transport_protocols[] = {
+    {0, "MCTP"}, {1, "NC-SI/RBT"}, {2, "Vendor Specific"}, {0, NULL}};
+
+static const value_string transfer_op_flags[] = {
+    {0x0, "Get Next Part"}, {0x1, "Get First Part"}, {0, NULL}};
+
+static const value_string transfer_flags[] = {{0x1, "Start"},
+                                              {0x2, "Middle"},
+                                              {0x4, "End"},
+                                              {0x5, "Start and End"},
+                                              {0, NULL}};
+
+int dissect_platform(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *p_tree,
+                     void *data) {
+
+  struct packet_data *d = (struct packet_data *)data;
+  guint8 offset = 0;
+  guint8 request = d->direction;
+  guint8 pldm_cmd = tvb_get_guint8(tvb, offset);
+  proto_tree_add_item(p_tree, hf_pldm_cmd, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+  offset += 1;
+  if (!request) {
+    proto_tree_add_item(p_tree, hf_completion_code, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    guint8 completion_code = tvb_get_guint8(tvb, offset);
+    if (completion_code)
+      return tvb_captured_length(tvb);
+    offset += 1;
+  }
+  switch (pldm_cmd) {
+  case 0x04: // Set Event Receiver command
+    if (request) {
+      proto_tree_add_item(p_tree, hf_event_message_global, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_transport_protocol_type, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      guint8 transport_protocol = tvb_get_guint8(tvb, offset);
+      offset += 1;
+      if (transport_protocol == 0) { // MCTP
+        proto_tree_add_item(p_tree, hf_event_receiver_addr_info, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        offset += 1;
+        proto_tree_add_item(p_tree, hf_heartbeat_timer, tvb, offset, 2,
+                            ENC_LITTLE_ENDIAN);
+      }
+    }
+    break;
+  case 0x0a: // Platform Event Message command
+    if (request) {
+      proto_tree_add_item(p_tree, hf_format_version, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_TID, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_event_class, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      guint8 event_class = tvb_get_guint8(tvb, offset);
+      offset += 1;
+      guint8 sensor_event_class;
+      /* Event Data */
+      switch (event_class) {
+      case 0x0: // Sensor
+        proto_tree_add_item(p_tree, hf_sensor_id, tvb, offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        offset += 2;
+        proto_tree_add_item(p_tree, hf_sensor_event_class, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        sensor_event_class = tvb_get_guint8(tvb, offset);
+        offset += 1;
+        if (sensor_event_class == 0) { // Sensor Operational State
+          proto_tree_add_item(p_tree, hf_sensor_op_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_sensor_prev_op_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+        } else if (sensor_event_class == 1) { // State Sensor State
+          proto_tree_add_item(p_tree, hf_sensor_offset, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_event_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_event_prev_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+        } else if (sensor_event_class == 2) { // Numeric Sensor State
+          proto_tree_add_item(p_tree, hf_event_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_event_prev_state, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_sensor_data_size, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          guint8 size = tvb_get_guint8(tvb, offset);
+          switch (size) {
+          case 0:
+            proto_tree_add_item(p_tree, hf_sensor_value_u8, tvb, offset, 1,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          case 1:
+            proto_tree_add_item(p_tree, hf_sensor_value_s8, tvb, offset, 1,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          case 2:
+            proto_tree_add_item(p_tree, hf_sensor_value_u16, tvb, offset, 2,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          case 3:
+            proto_tree_add_item(p_tree, hf_sensor_value_s16, tvb, offset, 2,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          case 4:
+            proto_tree_add_item(p_tree, hf_sensor_value_u32, tvb, offset, 4,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          case 5:
+            proto_tree_add_item(p_tree, hf_sensor_value_s32, tvb, offset, 4,
+                                ENC_LITTLE_ENDIAN);
+            break;
+          }
+        } else { // Invalid
+          col_append_fstr(pinfo->cinfo, COL_INFO, "Invalid byte");
+        }
+        break;
+      case 0x4: // PLDM PDR Repository Change Event
+        if (request) {
+          proto_tree_add_item(p_tree, hf_pdr_data_format, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_pdr_num_change_recs, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          // todo
+        }
+        break;
+      case 0x6: // Heartbeat elapsed
+        if (request) {
+          proto_tree_add_item(p_tree, hf_heartbeat_format_ver, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+          proto_tree_add_item(p_tree, hf_heartbeat_sequence_num, tvb, offset, 1,
+                              ENC_LITTLE_ENDIAN);
+          offset += 1;
+        }
+        break;
+      default:
+        g_print("To be implemented platform event message type %x\n",
+                event_class);
+      }
+    } else {
+      proto_tree_add_item(p_tree, hf_result_status, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  /*case 0x20: //SetStateSensorReadings
+          proto_tree_add_item(p_tree, hf_sensor_id, tvb, offset, 2,
+     ENC_LITTLE_ENDIAN); offset +=2; proto_tree_add_item(p_tree,
+     hf_sensor_composite_count, tvb, offset, 1, ENC_LITTLE_ENDIAN); offset +=1;
+          proto_tree_add_item(p_tree, hf_sensor_id, tvb, offset, 1,
+     ENC_LITTLE_ENDIAN); offset +=1; proto_tree_add_item(p_tree,
+     hf_sensor_op_state, tvb, offset, 1, ENC_LITTLE_ENDIAN); offset +=1;
+          proto_tree_add_item(p_tree, hf_sensor_event_msg_enable, tvb, offset,
+     1, ENC_LITTLE_ENDIAN); offset +=1; break;*/
+  case 0x21: // GetStateSensorReadings
+    if (request) {
+      proto_tree_add_item(p_tree, hf_sensor_id, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_sensor_rearm, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    } else {
+      proto_tree_add_item(p_tree, hf_sensor_composite_count, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      // state fields
+    }
+    break;
+  case 0x31: // SetNumericEffecterValue
+             // untested
+    if (request) {
+      proto_tree_add_item(p_tree, hf_effecter_id, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_effecter_datasize, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      guint8 size = tvb_get_guint8(tvb, offset);
+      switch (size) {
+      case 0:
+        proto_tree_add_item(p_tree, hf_effecter_value_u8, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      case 1:
+        proto_tree_add_item(p_tree, hf_effecter_value_s8, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      case 2:
+        proto_tree_add_item(p_tree, hf_effecter_value_u16, tvb, offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      case 3:
+        proto_tree_add_item(p_tree, hf_effecter_value_s16, tvb, offset, 2,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      case 4:
+        proto_tree_add_item(p_tree, hf_effecter_value_u32, tvb, offset, 4,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      case 5:
+        proto_tree_add_item(p_tree, hf_effecter_value_s32, tvb, offset, 4,
+                            ENC_LITTLE_ENDIAN);
+        break;
+      }
+    }
+    break;
+  case 0x39: // SetStateEffecterStates
+    if (request) {
+      proto_tree_add_item(p_tree, hf_effecter_id, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_effecter_count, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+    }
+    break;
+  case 0x51: // GetPDR
+    if (request) {
+      proto_tree_add_item(p_tree, hf_record_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_transfer_op_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_request_count, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      offset += 2;
+      proto_tree_add_item(p_tree, hf_record_change_num, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+
+    } else {
+      proto_tree_add_item(p_tree, hf_next_record_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_next_data_handle, tvb, offset, 4,
+                          ENC_LITTLE_ENDIAN);
+      offset += 4;
+      proto_tree_add_item(p_tree, hf_transfer_flag, tvb, offset, 1,
+                          ENC_LITTLE_ENDIAN);
+      guint8 transfer_flag = tvb_get_guint8(tvb, offset);
+      offset += 1;
+      proto_tree_add_item(p_tree, hf_response_count, tvb, offset, 2,
+                          ENC_LITTLE_ENDIAN);
+      guint16 response_count = tvb_get_guint16(tvb, offset, ENC_LITTLE_ENDIAN);
+      offset += 2;
+      if (response_count) {
+        // TODO add record data to tree
+        offset += response_count;
+      }
+      if (transfer_flag == 0x4) {
+        // CRC only present if flag == end
+        proto_tree_add_item(p_tree, hf_transfer_crc, tvb, offset, 1,
+                            ENC_LITTLE_ENDIAN);
+      }
+    }
+    break;
+  default:
+    col_append_fstr(pinfo->cinfo, COL_INFO,
+                    "Unsupported or Invalid PLDM command %x ", pldm_cmd);
+    g_print("Invalid PLDM platform cmd %x \n", pldm_cmd);
+    break;
+  }
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_platform(void) {
+  static hf_register_info hf[] = {
+      {&hf_pldm_cmd,
+       {"PLDM Command Type", "pldm.cmd", FT_UINT8, BASE_HEX, VALS(pldm_cmds),
+        0x0, NULL, HFILL}},
+      {&hf_completion_code,
+       {"Completion Code", "pldm.cc", FT_UINT8, BASE_DEC,
+        VALS(completion_codes), 0x0, NULL, HFILL}},
+      /* PDR */
+      {&hf_record_handle,
+       {"PDR record handle", "pldm.platform.pdr.record_handle", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_data_handle,
+       {"PDR data transfer handle", "pldm.platform.pdr.data_handle", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_transfer_op_flag,
+       {"PDR transfer operation flag", "pldm.platform.pdr.transfer_op_flag",
+        FT_UINT8, BASE_DEC, VALS(transfer_op_flags), 0x0, NULL, HFILL}},
+      {&hf_request_count,
+       {"PDR request count", "pldm.platform.pdr.request.count", FT_UINT16,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_record_change_num,
+       {"PDR record change number", "pldm.platform.pdr.record_change_number",
+        FT_UINT8, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_next_record_handle,
+       {"PDR next record handle", "pldm.platform.pdr.next_record_handle",
+        FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_next_data_handle,
+       {"PDR next data transfer handle", "pldm.platform.pdr.next_data_handle",
+        FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_transfer_flag,
+       {"PDR transfer flag", "pldm.platform.pdr.transfer_flag", FT_UINT8,
+        BASE_DEC, VALS(transfer_flags), 0x0, NULL, HFILL}},
+      {&hf_response_count,
+       {"PDR response count", "pldm.platform.pdr.response.count", FT_UINT16,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      // TODO
+      /*{ &hf_record_data,{
+         "PDR record data", "pldm.platform.pdr.data",
+         FT_UINT8, BASE_DEC,
+         NULL, 0x0,
+         NULL, HFILL}
+      },*/
+      {&hf_transfer_crc,
+       {"PDR transfer CRC", "pldm.platform.pdr.crc", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      /* Effecter */
+      {&hf_effecter_id,
+       {"Effecter ID", "pldm.platform.effecter.id", FT_UINT16, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_effecter_count,
+       {"Effecter count", "pldm.platform.effecter.count", FT_UINT8, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_datasize,
+       {"Effecter Data Size", "pldm.platform.effecter.datasize", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_u8,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_UINT8, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_s8,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_INT8, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_u16,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_UINT16, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_s16,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_INT16, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_u32,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_UINT32, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_effecter_value_s32,
+       {"Effecter Value", "pldm.platform.effecter.value", FT_INT32, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      /* Event Receiver */
+      {&hf_event_message_global,
+       {"Event message global enable", "pldm.platform.receiver.enable",
+        FT_UINT8, BASE_DEC, VALS(event_message_global_enable), 0x0, NULL,
+        HFILL}},
+      {&hf_transport_protocol_type,
+       {"Transport protocol", "pldm.platform.receiver.transport", FT_UINT8,
+        BASE_DEC, VALS(transport_protocols), 0x0, NULL, HFILL}},
+      // todo this varies in size based on transport protocol type
+      //  1 byte MCTP
+      //  X for NCSI
+      //  X for vendor specific
+      {&hf_event_receiver_addr_info,
+       {"Event receiver address info", "pldm.platform.receiver.addr_info",
+        FT_UINT8, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_heartbeat_timer,
+       {"Heartbeat timer", "pldm.platform.receiver.timer", FT_UINT16, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      /* Event message */
+      {&hf_format_version,
+       {"Format Version", "pldm.platform.event.format_version", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_TID,
+       {"TID", "pldm.platform.event.TID", FT_UINT8, BASE_DEC, NULL, 0x0, NULL,
+        HFILL}},
+      {&hf_event_class,
+       {"Event Class", "pldm.platform.event.class", FT_UINT8, BASE_DEC,
+        VALS(event_classes), 0x0, NULL, HFILL}},
+      {&hf_result_status,
+       {"Completion Code", "pldm.status", FT_UINT8, BASE_DEC,
+        VALS(result_status), 0x0, NULL, HFILL}},
+      {&hf_sensor_id,
+       {"Sensor ID", "pldm.platform.event.sensor_id", FT_UINT16, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_sensor_event_class,
+       {"Sensor event class", "pldm.platform.event.sensor_event_class",
+        FT_UINT8, BASE_DEC, VALS(sensor_event_classes), 0x0, NULL, HFILL}},
+      {&hf_sensor_offset,
+       {"Sensor offset", "pldm.platform.event.sensor_offset", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_event_state,
+       {"Event state", "pldm.platform.event.state", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_event_prev_state,
+       {"Event previous state", "pldm.platform.event.prev_state", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_data_size,
+       {"Sensor data size", "pldm.platform.sensor.data_size", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      /*         { &hf_sensor_event_msg_enable,{
+                  "Sensor event message enable",
+         "pldm.platform.sensor.event_msg_en", FT_UINT8, BASE_DEC, NULL, 0x0,
+                  NULL, HFILL}
+               },*/
+      {&hf_sensor_rearm,
+       {"Sensor rearm", "pldm.platform.sensor_rearm", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_sensor_composite_count,
+       {"Sensor composite count", "pldm.platform.sensor.comp_count", FT_UINT8,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_pdr_data_format,
+       {"PDR Repository change data format",
+        "pldm.platform.event.pdr.data_format", FT_UINT8, BASE_DEC, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_pdr_num_change_recs,
+       {"PDR Repository number of records changed",
+        "pldm.platform.event.pdr.num_records", FT_UINT8, BASE_DEC, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_sensor_value_u8,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_UINT8, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_value_s8,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_INT8, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_value_u16,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_UINT16,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_value_s16,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_INT16, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_value_u32,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_UINT32,
+        BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_value_s32,
+       {"Sensor reading", "pldm.platform.event.sensor.data", FT_INT32, BASE_DEC,
+        NULL, 0x0, NULL, HFILL}},
+      {&hf_sensor_op_state,
+       {"Sensor present operational state",
+        "pldm.platform.event.sensor.op_state", FT_UINT8, BASE_DEC, NULL, 0x0,
+        NULL, HFILL}},
+      {&hf_sensor_prev_op_state,
+       {"Sensor previous operational state",
+        "pldm.platform.event.sensor.prev_op_state", FT_UINT8, BASE_DEC, NULL,
+        0x0, NULL, HFILL}},
+      {&hf_heartbeat_format_ver,
+       {"Format Version", "pldm.platform.event.heartbeat.format_version",
+        FT_UINT8, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+      {&hf_heartbeat_sequence_num,
+       {"Heartbeat sequence number", "pldm.platform.event.heartbeat.seq",
+        FT_UINT8, BASE_DEC, NULL, 0x0, NULL, HFILL}},
+  };
+
+  proto_pldm_platform =
+      proto_register_protocol("PLDM Plaform Monitoring Protocol", /* name */
+                              "PLDM_P",       /* short_name  */
+                              "pldm.platform" /* filter_name */
+      );
+  proto_register_field_array(proto_pldm_platform, hf, array_length(hf));
+}
+
+void proto_reg_handoff_platform(void) {
+  static dissector_handle_t platform_handle;
+
+  platform_handle =
+      create_dissector_handle(dissect_platform, proto_pldm_platform);
+  dissector_add_uint("pldm.type", PLDM_PLATFORM, platform_handle);
+}

--- a/epan/dissectors/packet-pldm.c
+++ b/epan/dissectors/packet-pldm.c
@@ -1,0 +1,128 @@
+#include "config.h"
+#include <epan/packet.h>
+#include <stdint.h>
+
+#define PLDM_MIN_LENGTH 4
+#define PLDM_MAX_TYPES 8
+
+static const value_string directions[] = {{0, "response"},
+                                          {1, "reserved"},
+                                          {2, "request"},
+                                          {3, "async/unack"},
+                                          {0, NULL}};
+
+static const value_string pldm_types[] = {
+    {0, "PLDM Messaging and Discovery"},
+    {1, "PLDM for SMBIOS"},
+    {2, "PLDM Platform Monitoring and Control"},
+    {3, "PLDM for BIOS Control and Configuration"},
+    {4, "PLDM for FRU Data"},
+    {5, "PLDM for Firmware Update"},
+    {6, "PLDM for Redfish Device Enablement"},
+    {63, "OEM Specific"},
+    {0, NULL}};
+
+struct packet_data {
+  guint8 direction;
+  guint8 instance_id;
+};
+static int proto_pldm = -1;
+static int ett_pldm = -1;
+
+static int hf_direction = -1;
+static int hf_instance_id = -1;
+static int hf_header_version = -1;
+static int hf_pldm_type = -1;
+static int hf_reserve = -1;
+static dissector_table_t pldm_dissector_table;
+
+static int dissect_pldm(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree,
+                        void *data _U_) {
+  col_set_str(pinfo->cinfo, COL_PROTOCOL, "PLDM");
+  col_clear(pinfo->cinfo, COL_INFO);
+
+  tvbuff_t *next_tvb;
+  guint len, direction;
+  guint8 instID, pldm_type, offset;
+  int reported_length;
+  len = tvb_reported_length(tvb);
+  if (len < PLDM_MIN_LENGTH) {
+    col_add_fstr(pinfo->cinfo, COL_INFO, "Packet length %u, minimum %u", len,
+                 PLDM_MIN_LENGTH);
+    return tvb_captured_length(tvb);
+  }
+  if (tree) {
+    /* first byte is the MCTP msg type */
+    offset = 1;
+    proto_item *ti =
+        proto_tree_add_item(tree, proto_pldm, tvb, offset, -1, ENC_NA);
+    proto_tree *pldm_tree = proto_item_add_subtree(ti, ett_pldm);
+
+    proto_tree_add_item(pldm_tree, hf_direction, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    direction = tvb_get_bits8(tvb, offset * 8, 2);
+    proto_tree_add_item(pldm_tree, hf_reserve, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    proto_tree_add_item(pldm_tree, hf_instance_id, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    instID = tvb_get_guint8(tvb, offset);
+    instID = instID & 0x1F;
+    offset += 1;
+    pldm_type = tvb_get_bits8(tvb, offset * 8 + 2, 6);
+    proto_tree_add_item(pldm_tree, hf_header_version, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    proto_tree_add_item(pldm_tree, hf_pldm_type, tvb, offset, 1,
+                        ENC_LITTLE_ENDIAN);
+    offset += 1;
+    next_tvb = tvb_new_subset_remaining(tvb, offset);
+    offset += 1;
+    reported_length = tvb_reported_length_remaining(tvb, offset);
+
+    struct packet_data d = {direction, instID};
+    if (reported_length >= 1) {
+      dissector_try_uint_new(pldm_dissector_table, pldm_type & 0x3f, next_tvb,
+                             pinfo, pldm_tree, true, (void *)&d);
+      return tvb_captured_length(tvb);
+    }
+  }
+
+  return tvb_captured_length(tvb);
+}
+
+void proto_register_pldm(void) {
+  static hf_register_info hf[] = {
+      {&hf_direction,
+       {"Msg Direction", "pldm.direction", FT_UINT8, BASE_DEC, VALS(directions),
+        0xc0, NULL, HFILL}},
+      {&hf_reserve,
+       {"PLDM Reserve", "pldm.rsvd", FT_UINT8, BASE_DEC, NULL, 0x20, NULL,
+        HFILL}},
+      {&hf_instance_id,
+       {"PLDM Instance Id", "pldm.instance", FT_UINT8, BASE_DEC, NULL, 0x1F,
+        NULL, HFILL}},
+      {&hf_header_version,
+       {"PLDM Header Version", "pldm.hdr", FT_UINT8, BASE_DEC, NULL, 0xC0, NULL,
+        HFILL}},
+      {&hf_pldm_type,
+       {"PLDM Command Type", "pldm.type", FT_UINT8, BASE_HEX, VALS(pldm_types),
+        0x3f, NULL, HFILL}},
+  };
+
+  static gint *ett[] = {&ett_pldm};
+
+  proto_pldm = proto_register_protocol("PLDM Protocol", /* name        */
+                                       "PLDM",          /* short_name  */
+                                       "pldm"           /* filter_name */
+  );
+  proto_register_field_array(proto_pldm, hf, array_length(hf));
+  proto_register_subtree_array(ett, array_length(ett));
+  pldm_dissector_table = register_dissector_table(
+      "pldm.type", "PLDM type", proto_pldm, FT_UINT8, BASE_HEX);
+}
+
+void proto_reg_handoff_pldm(void) {
+  static dissector_handle_t pldm_handle;
+  pldm_handle = create_dissector_handle(dissect_pldm, proto_pldm);
+  dissector_add_uint("wtap_encap", 147, pldm_handle);
+  dissector_add_uint("mctp.type", 1, pldm_handle);
+}


### PR DESCRIPTION
This commit implemements PLDM dissector
for the protocol is done following DMTF
guideline documentation -
https://www.dmtf.org/sites/default/files/standards/documents/DSP0240_1.1.0.pdf

There is a basic implementation layout
for other PLDM specs whose DMTF guide-
line can be referred here -
https://www.dmtf.org/sites/default/files/standards/documents/DSP0245_1.0.0.pdf

Testing : For verification of dissector
pcap file collected during host poweron
is used.

Test PCAP : test_pcap/mctp-binding.pcap