### PR TITLE
UI hang due to bad messages injected from dumpcap

### DIFF
--- a/sync_pipe.h
+++ b/sync_pipe.h
@@ -34,6 +34,10 @@
    signed/unsigned 64-bit int */
 #define SP_DECISIZE 20
 
+/* Indicator status */
+#define SP_INDICATOR_OK   0
+#define SP_INDICATOR_ERR -2
+
 /*
  * Indications sent out on the sync pipe (from child to parent).
  * We might want to switch to something like Thrift


### PR DESCRIPTION
  * Some libraries may write error messages to the stderr. These messages will pollute the messages in sync pipe of dumpcap. In this case the wireshark will be confusing about these messages. This commit demostrate this issue.