### PR TITLE
[Bugfix] Dissector MessagePack: dissect all integer formats

### DIFF
--- a/epan/dissectors/packet-msgpack.c
+++ b/epan/dissectors/packet-msgpack.c
@@ -337,7 +337,7 @@ static void dissect_msgpack_object(tvbuff_t* tvb, packet_info* pinfo, proto_tree
 	}
 
 	// Integer
-	if (type > 0xe0 || type < 0x7f || type == 0xd3) {
+	if (type > 0xe0 || type < 0x7f || (type >= 0xcc && type <= 0xd3)) {
 		dissect_msgpack_integer(tvb, pinfo, tree, type, data, offset, value);
 		return;
 	}

--- a/epan/dissectors/packet-msgpack.c
+++ b/epan/dissectors/packet-msgpack.c
@@ -337,7 +337,7 @@ static void dissect_msgpack_object(tvbuff_t* tvb, packet_info* pinfo, proto_tree
 	}
 
 	// Integer
-	if (type > 0xe0 || type < 0x7f || (type >= 0xcc && type <= 0xd3)) {
+	if (type >= 0xe0 || type <= 0x7f || (type >= 0xcc && type <= 0xd3)) {
 		dissect_msgpack_integer(tvb, pinfo, tree, type, data, offset, value);
 		return;
 	}


### PR DESCRIPTION
This PR fixes two errors:

- The boundary of positive fixints includes 0x7f, the boundary of negative fixints includes 0xe0.
- More integer types are defined than were checked.

The implementation of `dissect_msgpack_integer` already handles all these cases correctly. 
The specification of MessagePack can be found here on [github](https://github.com/msgpack/msgpack/blob/master/spec.md).