### PR TITLE
fix dictionary.mikrotik attribute name

### DIFF
--- a/resources/protocols/radius/dictionary.mikrotik
+++ b/resources/protocols/radius/dictionary.mikrotik
@@ -43,7 +43,7 @@ ATTRIBUTE	Mikrotik-Wireless-Comment		21	string
 ATTRIBUTE	Mikrotik-Delegated-IPv6-Pool		22	string
 ATTRIBUTE	Mikrotik-DHCP-Option-Set		23	string
 ATTRIBUTE	Mikrotik-DHCP-Option-Param-STR1		24	string
-ATTRIBUTE	Mikortik-DHCP-Option-ParamSTR2		25	string
+ATTRIBUTE	Mikrotik-DHCP-Option-ParamSTR2		25	string
 ATTRIBUTE	Mikrotik-Wireless-VLANID		26	integer
 ATTRIBUTE	Mikrotik-Wireless-VLANID-Type		27	integer
 ATTRIBUTE	Mikrotik-Wireless-Minsignal		28	string


### PR DESCRIPTION
fix dictionary.mikrotik attribute name