### PR TITLE
Make changes to packet-ethercat-frame

### DIFF
--- a/plugins/epan/ethercat/packet-ethercat-frame.h
+++ b/plugins/epan/ethercat/packet-ethercat-frame.h
@@ -1,4 +1,4 @@
-/* paket-ethercat-frame.h
+/* packet-ethercat-frame.h
  *
  * Copyright (c) 2007 by Beckhoff Automation GmbH
  *


### PR DESCRIPTION
Fixed a typo in the header comment of this header file. Changed from 'paket' to 'packet'