### PR TITLE
CMake: Allow for divergent install directories

### DIFF
--- a/resources/wireshark.pc.in
+++ b/resources/wireshark.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 sharedlibdir=${libdir}
 plugindir=${libdir}/wireshark/@PLUGIN_VERSION_DIR@
 


### PR DESCRIPTION
In some build systems such as Nix, you can install includes and libs in directories which don't share the same parent. This allows for specified install paths to be respected.